### PR TITLE
Add missing @covers tags

### DIFF
--- a/tests/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
+++ b/tests/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
@@ -17,6 +17,8 @@ class MismatchingDataValueTypeExceptionTest extends \PHPUnit_Framework_TestCase 
 
 	/**
 	 * @dataProvider constructorProvider
+	 * @param string $expectedType
+	 * @param string $actualType
 	 */
 	public function testConstructorWithRequiredArguments( $expectedType, $actualType ) {
 		$exception = new MismatchingDataValueTypeException( $expectedType, $actualType );
@@ -27,6 +29,8 @@ class MismatchingDataValueTypeExceptionTest extends \PHPUnit_Framework_TestCase 
 
 	/**
 	 * @dataProvider constructorProvider
+	 * @param string $expectedType
+	 * @param string $actualType
 	 */
 	public function testConstructorWithAllArguments( $expectedType, $actualType ) {
 		$message = 'Onoez! an error!';

--- a/tests/ValueFormatters/StringFormatterTest.php
+++ b/tests/ValueFormatters/StringFormatterTest.php
@@ -5,9 +5,7 @@ namespace ValueFormatters\Test;
 use DataValues\StringValue;
 
 /**
- * Unit tests for the ValueFormatters\StringFormatter class.
- *
- * @since 0.1
+ * @covers ValueFormatters\StringFormatter
  *
  * @group ValueFormatters
  * @group DataValueExtensions
@@ -16,6 +14,15 @@ use DataValues\StringValue;
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class StringFormatterTest extends ValueFormatterTestBase {
+
+	/**
+	 * @see ValueFormatterTestBase::getFormatterClass
+	 *
+	 * @return string
+	 */
+	protected function getFormatterClass() {
+		return 'ValueFormatters\StringFormatter';
+	}
 
 	/**
 	 * @see ValueFormatterTestBase::validProvider
@@ -36,15 +43,6 @@ class StringFormatterTest extends ValueFormatterTestBase {
 		}
 
 		return $argLists;
-	}
-
-	/**
-	 * @see ValueFormatterTestBase::getFormatterClass
-	 *
-	 * @return string
-	 */
-	protected function getFormatterClass() {
-		return 'ValueFormatters\StringFormatter';
 	}
 
 }

--- a/tests/ValueParsers/BoolParserTest.php
+++ b/tests/ValueParsers/BoolParserTest.php
@@ -5,9 +5,7 @@ namespace ValueParsers\Test;
 use DataValues\BooleanValue;
 
 /**
- * Unit test BoolParser class.
- *
- * @since 0.1
+ * @covers ValueParsers\BoolParser
  *
  * @group ValueParsers
  * @group DataValueExtensions
@@ -16,6 +14,15 @@ use DataValues\BooleanValue;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class BoolParserTest extends StringValueParserTest {
+
+	/**
+	 * @see ValueParserTestBase::getParserClass
+	 *
+	 * @return string
+	 */
+	protected function getParserClass() {
+		return 'ValueParsers\BoolParser';
+	}
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
@@ -60,15 +67,6 @@ class BoolParserTest extends StringValueParserTest {
 		}
 
 		return $argLists;
-	}
-
-	/**
-	 * @see ValueParserTestBase::getParserClass
-	 *
-	 * @return string
-	 */
-	protected function getParserClass() {
-		return 'ValueParsers\BoolParser';
 	}
 
 }

--- a/tests/ValueParsers/FloatParserTest.php
+++ b/tests/ValueParsers/FloatParserTest.php
@@ -5,9 +5,7 @@ namespace ValueParsers\Test;
 use DataValues\NumberValue;
 
 /**
- * Unit test FloatParser class.
- *
- * @since 0.1
+ * @covers ValueParsers\FloatParser
  *
  * @group ValueParsers
  * @group DataValueExtensions
@@ -17,6 +15,15 @@ use DataValues\NumberValue;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class FloatParserTest extends StringValueParserTest {
+
+	/**
+	 * @see ValueParserTestBase::getParserClass
+	 *
+	 * @return string
+	 */
+	protected function getParserClass() {
+		return 'ValueParsers\FloatParser';
+	}
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
@@ -81,15 +88,6 @@ class FloatParserTest extends StringValueParserTest {
 		}
 
 		return $argLists;
-	}
-
-	/**
-	 * @see ValueParserTestBase::getParserClass
-	 *
-	 * @return string
-	 */
-	protected function getParserClass() {
-		return 'ValueParsers\FloatParser';
 	}
 
 }

--- a/tests/ValueParsers/IntParserTest.php
+++ b/tests/ValueParsers/IntParserTest.php
@@ -5,9 +5,7 @@ namespace ValueParsers\Test;
 use DataValues\NumberValue;
 
 /**
- * Unit test IntParser class.
- *
- * @since 0.1
+ * @covers ValueParsers\IntParser
  *
  * @group ValueParsers
  * @group DataValueExtensions
@@ -16,6 +14,15 @@ use DataValues\NumberValue;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class IntParserTest extends StringValueParserTest {
+
+	/**
+	 * @see ValueParserTestBase::getParserClass
+	 *
+	 * @return string
+	 */
+	protected function getParserClass() {
+		return 'ValueParsers\IntParser';
+	}
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
@@ -70,15 +77,6 @@ class IntParserTest extends StringValueParserTest {
 		}
 
 		return $argLists;
-	}
-
-	/**
-	 * @see ValueParserTestBase::getParserClass
-	 *
-	 * @return string
-	 */
-	protected function getParserClass() {
-		return 'ValueParsers\IntParser';
 	}
 
 }

--- a/tests/ValueParsers/NullParserTest.php
+++ b/tests/ValueParsers/NullParserTest.php
@@ -6,9 +6,7 @@ use DataValues\UnknownValue;
 use ValueParsers\ValueParser;
 
 /**
- * Unit test NullParser class.
- *
- * @since 0.1
+ * @covers ValueParsers\NullParser
  *
  * @group ValueParsers
  * @group DataValueExtensions
@@ -17,6 +15,15 @@ use ValueParsers\ValueParser;
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class NullParserTest extends ValueParserTestBase {
+
+	/**
+	 * @see ValueParserTestBase::getParserClass
+	 *
+	 * @return string
+	 */
+	protected function getParserClass() {
+		return 'ValueParsers\NullParser';
+	}
 
 	/**
 	 * @see ValueParserTestBase::validInputProvider
@@ -48,28 +55,20 @@ class NullParserTest extends ValueParserTestBase {
 	 * @see ValueParserTestBase::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
-		return array( array(
-			'This sucks; this parser has no invalid inputs, so this test should be skipped.' .
-			'Not clear how to do that in a way one does not get a "incomplete test" notice though'
-		) );
+		return array(
+			array( null )
+		);
 	}
 
 	/**
+	 * @see ValueParserTestBase::testParseWithInvalidInputs
+	 *
 	 * @dataProvider invalidInputProvider
-	 * @param $value
-	 * @param ValueParser $parser
+	 * @param mixed $value
+	 * @param ValueParser|null $parser
 	 */
 	public function testParseWithInvalidInputs( $value, ValueParser $parser = null ) {
-		$this->assertTrue( true );
-	}
-
-	/**
-	 * @see ValueParserTestBase::getParserClass
-	 *
-	 * @return string
-	 */
-	protected function getParserClass() {
-		return 'ValueParsers\NullParser';
+		$this->markTestSkipped( 'NullParser has no invalid inputs' );
 	}
 
 }

--- a/tests/ValueParsers/StringValueParserTest.php
+++ b/tests/ValueParsers/StringValueParserTest.php
@@ -17,23 +17,20 @@ use ValueParsers\StringValueParser;
  */
 abstract class StringValueParserTest extends ValueParserTestBase {
 
+	/**
+	 * @see ValueParserTestBase::invalidInputProvider
+	 *
+	 * @return array[]
+	 */
 	public function invalidInputProvider() {
-		$argLists = array();
-
-		$invalid = array(
-			true,
-			false,
-			null,
-			4.2,
-			array(),
-			42,
+		return array(
+			array( true ),
+			array( false ),
+			array( null ),
+			array( 4.2 ),
+			array( array() ),
+			array( 42 ),
 		);
-
-		foreach ( $invalid as $value ) {
-			$argLists[] = array( $value );
-		}
-
-		return $argLists;
 	}
 
 	public function testSetAndGetOptions() {

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -22,26 +22,28 @@ abstract class ValueParserTestBase extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @since 0.1
+	 *
 	 * @return string
 	 */
 	protected abstract function getParserClass();
 
 	/**
 	 * @since 0.1
+	 *
 	 * @return array[]
 	 */
 	public abstract function validInputProvider();
 
 	/**
 	 * @since 0.1
+	 *
 	 * @return array[]
 	 */
-	public function invalidInputProvider() {
-		return array();
-	}
+	public abstract function invalidInputProvider();
 
 	/**
 	 * @since 0.1
+	 *
 	 * @return ValueParser
 	 */
 	protected function getInstance() {
@@ -50,14 +52,15 @@ abstract class ValueParserTestBase extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider validInputProvider
 	 * @since 0.1
+	 *
+	 * @dataProvider validInputProvider
 	 * @param mixed $value
 	 * @param mixed $expected
 	 * @param ValueParser|null $parser
 	 */
 	public function testParseWithValidInputs( $value, $expected, ValueParser $parser = null ) {
-		if ( is_null( $parser ) ) {
+		if ( $parser === null ) {
 			$parser = $this->getInstance();
 		}
 
@@ -86,13 +89,14 @@ abstract class ValueParserTestBase extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @dataProvider invalidInputProvider
 	 * @since 0.1
+	 *
+	 * @dataProvider invalidInputProvider
 	 * @param mixed $value
 	 * @param ValueParser|null $parser
 	 */
 	public function testParseWithInvalidInputs( $value, ValueParser $parser = null ) {
-		if ( is_null( $parser ) ) {
+		if ( $parser === null ) {
 			$parser = $this->getInstance();
 		}
 


### PR DESCRIPTION
* Added missing `@covers`.
* Added missing docs.
* Removed some `@since` that don't make much sense in my opinion.
* Used `markTestSkipped` in `NullParserTest`.
* Moved all `getFormatterClass` methods to the top.
* Made `ValueParserTestBase::invalidInputProvider` abstract. A provider that returns an empty array does not work anyway. This will always result in an error.