### PR TITLE
Fix broken tests

### DIFF
--- a/tests/DataValues/MonolingualTextValueTest.php
+++ b/tests/DataValues/MonolingualTextValueTest.php
@@ -38,13 +38,11 @@ class MonolingualTextTest extends DataValueTest {
 	public function invalidConstructorArgumentsProvider() {
 		$argLists = array();
 
-		$argLists[] = array( 42 );
-		$argLists[] = array( array() );
-		$argLists[] = array( false );
-		$argLists[] = array( true );
-		$argLists[] = array( null );
-		$argLists[] = array( 'foo' );
-		$argLists[] = array( 'en' );
+		$argLists[] = array( 42, null );
+		$argLists[] = array( array(), null );
+		$argLists[] = array( false, null );
+		$argLists[] = array( true, null );
+		$argLists[] = array( null, null );
 		$argLists[] = array( 'en', 42 );
 		$argLists[] = array( 'en', false );
 		$argLists[] = array( 'en', array() );

--- a/tests/DataValues/MultilingualTextValueTest.php
+++ b/tests/DataValues/MultilingualTextValueTest.php
@@ -45,22 +45,13 @@ class MultilingualTextTest extends DataValueTest {
 	public function invalidConstructorArgumentsProvider() {
 		$argLists = array();
 
-		$argLists[] = array( 42 );
-		$argLists[] = array( false );
-		$argLists[] = array( true );
-		$argLists[] = array( null );
-		$argLists[] = array( 'foo' );
-		$argLists[] = array( 'en' );
-		$argLists[] = array( 'en', 42 );
-		$argLists[] = array( 'en', false );
-		$argLists[] = array( 'en', array() );
-		$argLists[] = array( 'en', null );
-		$argLists[] = array( '', 'foo' );
-		$argLists[] = array( 'en', 'foo' );
-		$argLists[] = array( 'en', ' foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz ' );
-		$argLists[] = array( new MonolingualTextValue( 'en', 'foo' ) );
-
+		$argLists[] = array( array( 42 ) );
+		$argLists[] = array( array( false ) );
+		$argLists[] = array( array( true ) );
+		$argLists[] = array( array( null ) );
+		$argLists[] = array( array( array() ) );
 		$argLists[] = array( array( 'foo' ) );
+
 		$argLists[] = array( array( 42 => 'foo' ) );
 		$argLists[] = array( array( '' => 'foo' ) );
 		$argLists[] = array( array( 'en' => 42 ) );


### PR DESCRIPTION
Non-optional constructor arguments don't necessarily throw an Exception you can catch in a test, depending on the PHP/HHVM version/configuration they may cause a runtime error instead.