### PR TITLE
Simplify options handling

### DIFF
--- a/tests/ValueParsers/StringValueParserTest.php
+++ b/tests/ValueParsers/StringValueParserTest.php
@@ -2,6 +2,7 @@
 
 namespace ValueParsers\Test;
 
+use ValueParsers\ParserOptions;
 use ValueParsers\StringValueParser;
 
 /**
@@ -34,18 +35,16 @@ abstract class StringValueParserTest extends ValueParserTestBase {
 	}
 
 	public function testSetAndGetOptions() {
-		$options = $this->newParserOptions();
-
 		/**
 		 * @var StringValueParser $parser
 		 */
 		$parser = $this->getInstance();
 
-		$parser->setOptions( $options );
+		$parser->setOptions( new ParserOptions() );
 
-		$this->assertEquals( $options, $parser->getOptions() );
+		$this->assertEquals( new ParserOptions(), $parser->getOptions() );
 
-		$options = $this->newParserOptions();
+		$options = new ParserOptions();
 		$options->setOption( '~=[,,_,,]:3', '~=[,,_,,]:3' );
 
 		$parser->setOptions( $options );

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -48,7 +48,7 @@ abstract class ValueParserTestBase extends \PHPUnit_Framework_TestCase {
 	 */
 	protected function getInstance() {
 		$class = $this->getParserClass();
-		return new $class( $this->newParserOptions() );
+		return new $class( new ParserOptions() );
 	}
 
 	/**
@@ -117,9 +117,7 @@ abstract class ValueParserTestBase extends \PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * Returns some parser options object with all required options for the parser under test set.
-	 *
-	 * @since 0.1
+	 * @deprecated since 0.3, just use a new ParserOptions() object or null.
 	 *
 	 * @return ParserOptions
 	 */


### PR DESCRIPTION
This removes quite some obsolete code.

Originally the goal was to remove the unused newParserOptions method and to simplify the getInstance methods as much as possible. The additional changes are very closely related.