### PR TITLE
Deprecate getParserClass in favor of getInstance

### DIFF
--- a/tests/ValueParsers/BoolParserTest.php
+++ b/tests/ValueParsers/BoolParserTest.php
@@ -3,6 +3,7 @@
 namespace ValueParsers\Test;
 
 use DataValues\BooleanValue;
+use ValueParsers\BoolParser;
 
 /**
  * @covers ValueParsers\BoolParser
@@ -16,12 +17,12 @@ use DataValues\BooleanValue;
 class BoolParserTest extends StringValueParserTest {
 
 	/**
-	 * @see ValueParserTestBase::getParserClass
+	 * @see ValueParserTestBase::getInstance
 	 *
-	 * @return string
+	 * @return BoolParser
 	 */
-	protected function getParserClass() {
-		return 'ValueParsers\BoolParser';
+	protected function getInstance() {
+		return new BoolParser();
 	}
 
 	/**

--- a/tests/ValueParsers/FloatParserTest.php
+++ b/tests/ValueParsers/FloatParserTest.php
@@ -3,6 +3,7 @@
 namespace ValueParsers\Test;
 
 use DataValues\NumberValue;
+use ValueParsers\FloatParser;
 
 /**
  * @covers ValueParsers\FloatParser
@@ -17,12 +18,12 @@ use DataValues\NumberValue;
 class FloatParserTest extends StringValueParserTest {
 
 	/**
-	 * @see ValueParserTestBase::getParserClass
+	 * @see ValueParserTestBase::getInstance
 	 *
-	 * @return string
+	 * @return FloatParser
 	 */
-	protected function getParserClass() {
-		return 'ValueParsers\FloatParser';
+	protected function getInstance() {
+		return new FloatParser();
 	}
 
 	/**

--- a/tests/ValueParsers/IntParserTest.php
+++ b/tests/ValueParsers/IntParserTest.php
@@ -3,6 +3,7 @@
 namespace ValueParsers\Test;
 
 use DataValues\NumberValue;
+use ValueParsers\IntParser;
 
 /**
  * @covers ValueParsers\IntParser
@@ -16,12 +17,12 @@ use DataValues\NumberValue;
 class IntParserTest extends StringValueParserTest {
 
 	/**
-	 * @see ValueParserTestBase::getParserClass
+	 * @see ValueParserTestBase::getInstance
 	 *
-	 * @return string
+	 * @return IntParser
 	 */
-	protected function getParserClass() {
-		return 'ValueParsers\IntParser';
+	protected function getInstance() {
+		return new IntParser();
 	}
 
 	/**

--- a/tests/ValueParsers/NullParserTest.php
+++ b/tests/ValueParsers/NullParserTest.php
@@ -3,6 +3,7 @@
 namespace ValueParsers\Test;
 
 use DataValues\UnknownValue;
+use ValueParsers\NullParser;
 use ValueParsers\ValueParser;
 
 /**
@@ -17,12 +18,12 @@ use ValueParsers\ValueParser;
 class NullParserTest extends ValueParserTestBase {
 
 	/**
-	 * @see ValueParserTestBase::getParserClass
+	 * @see ValueParserTestBase::getInstance
 	 *
-	 * @return string
+	 * @return NullParser
 	 */
-	protected function getParserClass() {
-		return 'ValueParsers\NullParser';
+	protected function getInstance() {
+		return new NullParser();
 	}
 
 	/**

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -4,6 +4,8 @@ namespace ValueParsers\Test;
 
 use Comparable;
 use DataValues\DataValue;
+use LogicException;
+use PHPUnit_Framework_TestCase;
 use ValueParsers\ParserOptions;
 use ValueParsers\ValueParser;
 
@@ -18,14 +20,18 @@ use ValueParsers\ValueParser;
  * @licence GNU GPL v2+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class ValueParserTestBase extends \PHPUnit_Framework_TestCase {
+abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * @since 0.1
+	 * @deprecated since 0.3, override the getInstance method instead.
 	 *
 	 * @return string
 	 */
-	protected abstract function getParserClass();
+	protected function getParserClass() {
+		throw new LogicException(
+			'ValueParserTestBase subclasses either need to override getParserClass or getInstance'
+		);
+	}
 
 	/**
 	 * @since 0.1
@@ -43,6 +49,7 @@ abstract class ValueParserTestBase extends \PHPUnit_Framework_TestCase {
 
 	/**
 	 * @since 0.1
+	 * @todo Should become abstract when getParserClass is removed.
 	 *
 	 * @return ValueParser
 	 */
@@ -101,7 +108,6 @@ abstract class ValueParserTestBase extends \PHPUnit_Framework_TestCase {
 		}
 
 		$this->setExpectedException( 'ValueParsers\ParseException' );
-
 		$parser->parse( $value );
 	}
 


### PR DESCRIPTION
Just create an instance instead of using PHP's dark magic to turn a string into an object. This makes it much easier for tools to find usages, for example.