### PR TITLE
Drop ValueParserTestBase::getParserClass

### DIFF
--- a/Common.php
+++ b/Common.php
@@ -15,7 +15,7 @@ if ( defined( 'DataValuesCommon_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_COMMON_VERSION', '0.2.3' );
+define( 'DATAVALUES_COMMON_VERSION', '0.3.0 alpha' );
 
 /**
  * @deprecated

--- a/README.md
+++ b/README.md
@@ -49,6 +49,11 @@ DataValues Common has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.3.0 (alpha)
+
+* Dropped `ValueParserTestBase::getParserClass`
+* Made `ValueParserTestBase::getInstance` abstract
+
 ### 0.2.3 (2014-10-09)
 
 * Introduced `FORMAT_NAME` class constants on ValueParsers in order to use them as expectedFormat

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "0.2.x-dev"
+			"dev-master": "0.3.x-dev"
 		}
 	},
 	"autoload": {

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -4,7 +4,6 @@ namespace ValueParsers\Test;
 
 use Comparable;
 use DataValues\DataValue;
-use LogicException;
 use PHPUnit_Framework_TestCase;
 use ValueParsers\ParserOptions;
 use ValueParsers\ValueParser;
@@ -23,17 +22,6 @@ use ValueParsers\ValueParser;
 abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * @deprecated since 0.3, override the getInstance method instead.
-	 *
-	 * @return string
-	 */
-	protected function getParserClass() {
-		throw new LogicException(
-			'ValueParserTestBase subclasses either need to override getParserClass or getInstance'
-		);
-	}
-
-	/**
 	 * @since 0.1
 	 *
 	 * @return array[]
@@ -49,14 +37,10 @@ abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @since 0.1
-	 * @todo Should become abstract when getParserClass is removed.
 	 *
 	 * @return ValueParser
 	 */
-	protected function getInstance() {
-		$class = $this->getParserClass();
-		return new $class( new ParserOptions() );
-	}
+	protected abstract function getInstance();
 
 	/**
 	 * @since 0.1


### PR DESCRIPTION
Similar to https://github.com/DataValues/Interfaces/pull/10:

Please review #23 (commit 1) first, merge it, then rebase this patch and review it separately. Or even better: Please move this component to Gerrit so I can create an actual chain that's actually reviewable?

Also: Why is this base class in Common while the other is in Interfaces?

Bug: [T92268](https://phabricator.wikimedia.org/T92268)