### PR TITLE
Updated composer.json to PSR-4 autoloader.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,10 +36,10 @@
 		"files" : [
 			"Common.php"
 		],
-		"psr-0": {
-			"DataValues\\": "src",
-			"ValueFormatters\\": "src",
-			"ValueParsers\\": "src"
+		"psr-4": {
+			"DataValues\\": "src/DataValues/",
+			"ValueFormatters\\": "src/ValueFormatters/",
+			"ValueParsers\\": "src/ValueParsers/"
 		},
 		"classmap": [
 			"tests/ValueParsers"


### PR DESCRIPTION
The PSR-0 format has been deprecated in favor of PSR-4. For details, see:

* http://www.php-fig.org/psr/psr-0/
* http://www.php-fig.org/psr/psr-4/
* https://github.com/php-fig/fig-standards/commit/61f2d259