### PR TITLE
Remove --coverage-php option

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -48,7 +48,7 @@
 	"scripts": {
 		"test": [
 			"composer validate --no-interaction",
-			"phpunit --coverage-php /dev/null"
+			"phpunit"
 		],
 		"ci": [
 			"composer test"


### PR DESCRIPTION
The difference (on my machine) is ~100 ms versus ~1 second. That's sooo much slower that it's not worth the benefit, in my opinion. It would be cool to have this coverage test run once a day or something like this, but it should not slow down CI.