### PR TITLE
1.0.0 release

### DIFF
--- a/Common.php
+++ b/Common.php
@@ -15,7 +15,7 @@ if ( defined( 'DATAVALUES_COMMON_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_COMMON_VERSION', '0.3.0' );
+define( 'DATAVALUES_COMMON_VERSION', '1.0.0' );
 
 if ( defined( 'MEDIAWIKI' ) ) {
 	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(

--- a/README.md
+++ b/README.md
@@ -22,11 +22,11 @@ The recommended way to use this library is via [Composer](http://getcomposer.org
 To add this package as a local, per-project dependency to your project, simply add a
 dependency on `data-values/common` to your project's `composer.json` file.
 Here is a minimal example of a `composer.json` file that just defines a dependency on
-version 0.3 of this package:
+version 1.x of this package:
 
     {
         "require": {
-            "data-values/common": "0.3.*"
+            "data-values/common": "~1.0"
         }
     }
 
@@ -49,7 +49,7 @@ DataValues Common has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
-### 0.3.0 (2015-08-11)
+### 1.0.0 (2015-08-12)
 
 * Added `DispatchingValueParser`
 * Added `StringNormalizer` interface

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 	},
 	"extra": {
 		"branch-alias": {
-			"dev-master": "0.3.x-dev"
+			"dev-master": "1.0.x-dev"
 		}
 	},
 	"autoload": {

--- a/src/ValueParsers/DispatchingValueParser.php
+++ b/src/ValueParsers/DispatchingValueParser.php
@@ -8,7 +8,7 @@ use InvalidArgumentException;
  * A generic value parser that forwards parsing to a list of other value parsers and returns the
  * result of the first parse attempt that succeeded.
  *
- * @since 0.3
+ * @since 1.0
  *
  * @licence GNU GPL v2+
  * @author Thiemo Mättig

--- a/src/ValueParsers/Normalizers/NullStringNormalizer.php
+++ b/src/ValueParsers/Normalizers/NullStringNormalizer.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 /**
  * Null implementation of StringNormalizer.
  *
- * @since 0.3
+ * @since 1.0
  *
  * @license GPL 2+
  * @author Daniel Kinzler

--- a/src/ValueParsers/Normalizers/StringNormalizer.php
+++ b/src/ValueParsers/Normalizers/StringNormalizer.php
@@ -7,7 +7,7 @@ use InvalidArgumentException;
 /**
  * Interface for string normalization.
  *
- * @since 0.3
+ * @since 1.0
  *
  * @license GPL 2+
  * @author Daniel Kinzler

--- a/src/ValueParsers/StringParser.php
+++ b/src/ValueParsers/StringParser.php
@@ -10,7 +10,7 @@ use ValueParsers\Normalizers\StringNormalizer;
 /**
  * Implementation of the ValueParser interface for StringValues.
  *
- * @since 0.3
+ * @since 1.0
  *
  * @licence GNU GPL v2+
  * @author Daniel Kinzler


### PR DESCRIPTION
Making use of the first breaking release since 2013 to correct the version number. This has already been done for most other components.

There is some disagreement by @thiemowmde, though I personally do not understand what the exact objection is.

As per [semver.org](http://semver.org/):

> How do I know when to release 1.0.0?
> 
> If your software is being used in production, it should probably already be 1.0.0. If you have a stable API on which users have come to depend, you should be 1.0.0. If you're worrying a lot about backwards compatibility, you should probably already be 1.0.0.
