### PR TITLE
Fix mistake in 0.2.2 documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ DataValues Common has been written by the Wikidata team, as [Wikimedia Germany]
 
 ### 0.2.2 (2014-04-11)
 
-* Introduced `DataValueMismatchException`
+* Added `MismatchingDataValueTypeException`
 
 ### 0.2.1 (2014-03-12)
 

--- a/src/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
+++ b/src/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
@@ -6,7 +6,7 @@ use Exception;
 use ValueFormatters\FormattingException;
 
 /**
- * @since 0.2.1
+ * @since 0.2.2
  *
  * @licence GNU GPL v2+
  * @author Katie Filbert < aude.wiki@gmail.com >

--- a/tests/ValueParsers/BoolParserTest.php
+++ b/tests/ValueParsers/BoolParserTest.php
@@ -55,6 +55,9 @@ class BoolParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 

--- a/tests/ValueParsers/FloatParserTest.php
+++ b/tests/ValueParsers/FloatParserTest.php
@@ -64,6 +64,9 @@ class FloatParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 

--- a/tests/ValueParsers/IntParserTest.php
+++ b/tests/ValueParsers/IntParserTest.php
@@ -52,6 +52,9 @@ class IntParserTest extends StringValueParserTest {
 		return $argLists;
 	}
 
+	/**
+	 * @see StringValueParserTest::invalidInputProvider
+	 */
 	public function invalidInputProvider() {
 		$argLists = parent::invalidInputProvider();
 

--- a/tests/ValueParsers/StringValueParserTest.php
+++ b/tests/ValueParsers/StringValueParserTest.php
@@ -20,8 +20,6 @@ abstract class StringValueParserTest extends ValueParserTestBase {
 
 	/**
 	 * @see ValueParserTestBase::invalidInputProvider
-	 *
-	 * @return array[]
 	 */
 	public function invalidInputProvider() {
 		return array(


### PR DESCRIPTION
* Misspelled class name in the release notes and wrong version number in the class.
* Remove non-helpful return tag.
* Add see tags to methods implementing an abstract base.