### PR TITLE
Fix untested MismatchingDataValueTypeException

### DIFF
--- a/src/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
+++ b/src/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
@@ -10,6 +10,7 @@ use ValueFormatters\FormattingException;
  *
  * @licence GNU GPL v2+
  * @author Katie Filbert < aude.wiki@gmail.com >
+ * @author Thiemo Mättig
  */
 class MismatchingDataValueTypeException extends FormattingException {
 
@@ -29,14 +30,19 @@ class MismatchingDataValueTypeException extends FormattingException {
 	 * @param string $message
 	 * @param Exception|null $previous
 	 */
-	public function __construct( $expectedValueType, $dataValueType, $message = '',
+	public function __construct(
+		$expectedValueType,
+		$dataValueType,
+		$message = '',
 		Exception $previous = null
 	) {
 		$this->expectedValueType = $expectedValueType;
 		$this->dataValueType = $dataValueType;
 
-		$message = '$dataValueType "' . $dataValueType . '" does not match $expectedValueType "'
-			. $expectedValueType . '": $message';
+		if ( $message === '' ) {
+			$message = 'Data value type "' . $dataValueType . '" does not match expected "'
+				. $expectedValueType . '"';
+		}
 
 		parent::__construct( $message, 0, $previous );
 	}

--- a/tests/ValueFormatters/Exceptions/MismatchingDataValueTypeExceptionTest.php
+++ b/tests/ValueFormatters/Exceptions/MismatchingDataValueTypeExceptionTest.php
@@ -2,6 +2,8 @@
 
 namespace ValueFormatters\Tests\Exceptions;
 
+use Exception;
+use PHPUnit_Framework_TestCase;
 use ValueFormatters\Exceptions\MismatchingDataValueTypeException;
 
 /**
@@ -12,29 +14,31 @@ use ValueFormatters\Exceptions\MismatchingDataValueTypeException;
  *
  * @licence GNU GPL v2+
  * @author Katie Filbert < aude.wiki@gmail.com >
+ * @author Thiemo Mättig
  */
-class MismatchingDataValueTypeExceptionTest extends \PHPUnit_Framework_TestCase {
+class MismatchingDataValueTypeExceptionTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider constructorProvider
-	 * @param string $expectedType
-	 * @param string $actualType
 	 */
 	public function testConstructorWithRequiredArguments( $expectedType, $actualType ) {
 		$exception = new MismatchingDataValueTypeException( $expectedType, $actualType );
 
-		$this->assertEquals( $actualType, $exception->getDataValueType() );
-		$this->assertEquals( $expectedType, $exception->getExpectedValueType() );
+		$this->assertSame( $expectedType, $exception->getExpectedValueType() );
+		$this->assertSame( $actualType, $exception->getDataValueType() );
+		$this->assertSame(
+			"Data value type \"$actualType\" does not match expected \"$expectedType\"",
+			$exception->getMessage()
+		);
+		$this->assertNull( $exception->getPrevious() );
 	}
 
 	/**
 	 * @dataProvider constructorProvider
-	 * @param string $expectedType
-	 * @param string $actualType
 	 */
 	public function testConstructorWithAllArguments( $expectedType, $actualType ) {
 		$message = 'Onoez! an error!';
-		$previous = new \Exception( 'Onoez!' );
+		$previous = new Exception( 'Onoez!' );
 
 		$exception = new MismatchingDataValueTypeException(
 			$expectedType,
@@ -43,10 +47,10 @@ class MismatchingDataValueTypeExceptionTest extends \PHPUnit_Framework_TestCase 
 			$previous
 		);
 
-		$this->assertEquals( $actualType, $exception->getDataValueType() );
-		$this->assertEquals( $expectedType, $exception->getExpectedValueType() );
-		$this->assertContains( $message, $exception->getMessage() );
-		$this->assertEquals( $previous, $exception->getPrevious() );
+		$this->assertSame( $expectedType, $exception->getExpectedValueType() );
+		$this->assertSame( $actualType, $exception->getDataValueType() );
+		$this->assertSame( $message, $exception->getMessage() );
+		$this->assertSame( $previous, $exception->getPrevious() );
 	}
 
 	public function constructorProvider() {


### PR DESCRIPTION
It seems this test was never executed. Note the actual bug in the class (the single-quoted `$message`).