### PR TITLE
Add missing tests and simplify providers

### DIFF
--- a/tests/DataValues/MonolingualTextValueTest.php
+++ b/tests/DataValues/MonolingualTextValueTest.php
@@ -27,35 +27,59 @@ class MonolingualTextValueTest extends DataValueTest {
 	}
 
 	public function validConstructorArgumentsProvider() {
-		$argLists = [];
-
-		$argLists[] = [ 'en', 'foo' ];
-		$argLists[] = [ 'en', ' foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz ' ];
-
-		return $argLists;
+		return [
+			[ 'en', 'foo' ],
+			[ 'en', ' foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz ' ],
+		];
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$argLists = [];
+		return [
+			[ 42, null ],
+			[ [], null ],
+			[ false, null ],
+			[ true, null ],
+			[ null, null ],
+			[ 'en', 42 ],
+			[ 'en', false ],
+			[ 'en', [] ],
+			[ 'en', null ],
+			[ '', 'foo' ],
+		];
+	}
 
-		$argLists[] = [ 42, null ];
-		$argLists[] = [ [], null ];
-		$argLists[] = [ false, null ];
-		$argLists[] = [ true, null ];
-		$argLists[] = [ null, null ];
-		$argLists[] = [ 'en', 42 ];
-		$argLists[] = [ 'en', false ];
-		$argLists[] = [ 'en', [] ];
-		$argLists[] = [ 'en', null ];
-		$argLists[] = [ '', 'foo' ];
+	public function testNewFromArray() {
+		$array = [ 'text' => 'foo', 'language' => 'en' ];
+		$value = MonolingualTextValue::newFromArray( $array );
+		$this->assertSame( $array, $value->getArrayValue() );
+	}
 
-		return $argLists;
+	/**
+	 * @dataProvider invalidArrayProvider
+	 */
+	public function testNewFromArrayWithInvalidArray( array $array ) {
+		$this->setExpectedException( 'DataValues\IllegalValueException' );
+		MonolingualTextValue::newFromArray( $array );
+	}
+
+	public function invalidArrayProvider() {
+		return [
+			[ [] ],
+			[ [ null ] ],
+			[ [ '' ] ],
+			[ [ 'en', 'foo' ] ],
+			[ [ 'language' => 'en' ] ],
+			[ [ 'text' => 'foo' ] ],
+		];
+	}
+
+	public function testGetSortKey() {
+		$value = new MonolingualTextValue( 'en', 'foo' );
+		$this->assertSame( 'enfoo', $value->getSortKey() );
 	}
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param MonolingualTextValue $text
-	 * @param array $arguments
 	 */
 	public function testGetText( MonolingualTextValue $text, array $arguments ) {
 		$this->assertEquals( $arguments[1], $text->getText() );
@@ -63,8 +87,6 @@ class MonolingualTextValueTest extends DataValueTest {
 
 	/**
 	 * @dataProvider instanceProvider
-	 * @param MonolingualTextValue $text
-	 * @param array $arguments
 	 */
 	public function testGetLanguageCode( MonolingualTextValue $text, array $arguments ) {
 		$this->assertEquals( $arguments[0], $text->getLanguageCode() );

--- a/tests/DataValues/MultilingualTextValueTest.php
+++ b/tests/DataValues/MultilingualTextValueTest.php
@@ -28,42 +28,100 @@ class MultilingualTextValueTest extends DataValueTest {
 	}
 
 	public function validConstructorArgumentsProvider() {
-		$argLists = [];
-
-		$argLists[] = [ [] ];
-		$argLists[] = [ [ new MonolingualTextValue( 'en', 'foo' ) ] ];
-		$argLists[] = [ [ new MonolingualTextValue( 'en', 'foo' ), new MonolingualTextValue( 'de', 'foo' ) ] ];
-		$argLists[] = [ [ new MonolingualTextValue( 'en', 'foo' ), new MonolingualTextValue( 'de', 'bar' ) ] ];
-		$argLists[] = [ [
-			new MonolingualTextValue( 'en', 'foo' ),
-			new MonolingualTextValue( 'de', ' foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz ' )
-		] ];
-
-		return $argLists;
+		return [
+			[ [] ],
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+			] ],
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+				new MonolingualTextValue( 'de', 'foo' ),
+			] ],
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+				new MonolingualTextValue( 'de', 'bar' ),
+			] ],
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+				new MonolingualTextValue( 'de', ' foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz ' ),
+			] ],
+		];
 	}
 
 	public function invalidConstructorArgumentsProvider() {
-		$argLists = [];
+		return [
+			[ [ 42 ] ],
+			[ [ false ] ],
+			[ [ true ] ],
+			[ [ null ] ],
+			[ [ [] ] ],
+			[ [ 'foo' ] ],
 
-		$argLists[] = [ [ 42 ] ];
-		$argLists[] = [ [ false ] ];
-		$argLists[] = [ [ true ] ];
-		$argLists[] = [ [ null ] ];
-		$argLists[] = [ [ [] ] ];
-		$argLists[] = [ [ 'foo' ] ];
+			[ [ 42 => 'foo' ] ],
+			[ [ '' => 'foo' ] ],
+			[ [ 'en' => 42 ] ],
+			[ [ 'en' => null ] ],
+			[ [ 'en' => true ] ],
+			[ [ 'en' => [] ] ],
+			[ [ 'en' => 4.2 ] ],
 
-		$argLists[] = [ [ 42 => 'foo' ] ];
-		$argLists[] = [ [ '' => 'foo' ] ];
-		$argLists[] = [ [ 'en' => 42 ] ];
-		$argLists[] = [ [ 'en' => null ] ];
-		$argLists[] = [ [ 'en' => true ] ];
-		$argLists[] = [ [ 'en' => [] ] ];
-		$argLists[] = [ [ 'en' => 4.2 ] ];
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+				false,
+			] ],
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+				'foobar',
+			] ],
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+				new MonolingualTextValue( 'en', 'bar' ),
+			] ],
+		];
+	}
 
-		$argLists[] = [ [ new MonolingualTextValue( 'en', 'foo' ), false ] ];
-		$argLists[] = [ [ new MonolingualTextValue( 'en', 'foo' ), 'foobar' ] ];
+	public function testNewFromArray() {
+		$array = [ [ 'text' => 'foo', 'language' => 'en' ] ];
+		$value = MultilingualTextValue::newFromArray( $array );
+		$this->assertSame( $array, $value->getArrayValue() );
+	}
 
-		return $argLists;
+	/**
+	 * @dataProvider invalidArrayProvider
+	 */
+	public function testNewFromArrayWithInvalidArray( array $array ) {
+		$this->setExpectedException( 'DataValues\IllegalValueException' );
+		MultilingualTextValue::newFromArray( $array );
+	}
+
+	public function invalidArrayProvider() {
+		return [
+			[ [ null ] ],
+			[ [ '' ] ],
+			[ [ [] ] ],
+			[ [ [ 'en', 'foo' ] ] ],
+		];
+	}
+
+	/**
+	 * @dataProvider getSortKeyProvider
+	 */
+	public function testGetSortKey( array $monolingualValues, $expected ) {
+		$value = new MultilingualTextValue( $monolingualValues );
+		$this->assertSame( $expected, $value->getSortKey() );
+	}
+
+	public function getSortKeyProvider() {
+		return [
+			[ [], '' ],
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+			], 'enfoo' ],
+			[ [
+				new MonolingualTextValue( 'en', 'foo' ),
+				new MonolingualTextValue( 'de', 'bar' ),
+			], 'enfoo' ],
+		];
 	}
 
 	/**

--- a/tests/ValueFormatters/StringFormatterTest.php
+++ b/tests/ValueFormatters/StringFormatterTest.php
@@ -39,21 +39,30 @@ class StringFormatterTest extends ValueFormatterTestBase {
 	 * @see ValueFormatterTestBase::validProvider
 	 */
 	public function validProvider() {
-		$strings = [
-			'ice cream',
-			'cake',
-			'',
-			' a ',
-			'  ',
+		return [
+			[ new StringValue( 'ice cream' ), 'ice cream' ],
+			[ new StringValue( 'cake' ), 'cake' ],
+			[ new StringValue( '' ), '' ],
+			[ new StringValue( ' a ' ), ' a ' ],
+			[ new StringValue( '  ' ), '  ' ],
 		];
+	}
 
-		$argLists = [];
+	/**
+	 * @dataProvider invalidProvider
+	 */
+	public function testInvalidFormat( $value ) {
+		$formatter = new StringFormatter();
+		$this->setExpectedException( 'InvalidArgumentException' );
+		$formatter->format( $value );
+	}
 
-		foreach ( $strings as $string ) {
-			$argLists[] = [ new StringValue( $string ), $string ];
-		}
-
-		return $argLists;
+	public function invalidProvider() {
+		return [
+			[ null ],
+			[ 0 ],
+			[ '' ],
+		];
 	}
 
 }

--- a/tests/ValueParsers/BoolParserTest.php
+++ b/tests/ValueParsers/BoolParserTest.php
@@ -7,6 +7,7 @@ use ValueParsers\BoolParser;
 
 /**
  * @covers ValueParsers\BoolParser
+ * @covers ValueParsers\StringValueParser
  *
  * @group ValueParsers
  * @group DataValueExtensions
@@ -29,30 +30,21 @@ class BoolParserTest extends StringValueParserTest {
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
-		$argLists = [];
+		return [
+			[ 'yes', new BooleanValue( true ) ],
+			[ 'on', new BooleanValue( true ) ],
+			[ '1', new BooleanValue( true ) ],
+			[ 'true', new BooleanValue( true ) ],
+			[ 'no', new BooleanValue( false ) ],
+			[ 'off', new BooleanValue( false ) ],
+			[ '0', new BooleanValue( false ) ],
+			[ 'false', new BooleanValue( false ) ],
 
-		$valid = [
-			'yes' => true,
-			'on' => true,
-			'1' => true,
-			'true' => true,
-			'no' => false,
-			'off' => false,
-			'0' => false,
-			'false' => false,
-
-			'YeS' => true,
-			'ON' => true,
-			'No' => false,
-			'OfF' => false,
+			[ 'YeS', new BooleanValue( true ) ],
+			[ 'ON', new BooleanValue( true ) ],
+			[ 'No', new BooleanValue( false ) ],
+			[ 'OfF', new BooleanValue( false ) ],
 		];
-
-		foreach ( $valid as $value => $expected ) {
-			$expected = new BooleanValue( $expected );
-			$argLists[] = [ (string)$value, $expected ];
-		}
-
-		return $argLists;
 	}
 
 	/**

--- a/tests/ValueParsers/FloatParserTest.php
+++ b/tests/ValueParsers/FloatParserTest.php
@@ -7,6 +7,7 @@ use ValueParsers\FloatParser;
 
 /**
  * @covers ValueParsers\FloatParser
+ * @covers ValueParsers\StringValueParser
  *
  * @group ValueParsers
  * @group DataValueExtensions
@@ -29,41 +30,26 @@ class FloatParserTest extends StringValueParserTest {
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
-		$argLists = [];
-
-		$valid = [
+		return [
 			// Ignoring a single trailing newline is an intended PCRE feature
-			"0\n" => 0,
+			[ "0\n", new NumberValue( 0.0 ) ],
 
-			'0' => 0,
-			'1' => 1,
-			'42' => 42,
-			'01' => 01,
-			'9001' => 9001,
-			'-1' => -1,
-			'-42' => -42,
+			[ '0', new NumberValue( 0.0 ) ],
+			[ '1', new NumberValue( 1.0 ) ],
+			[ '42', new NumberValue( 42.0 ) ],
+			[ '01', new NumberValue( 1.0 ) ],
+			[ '9001', new NumberValue( 9001.0 ) ],
+			[ '-1', new NumberValue( -1.0 ) ],
+			[ '-42', new NumberValue( -42.0 ) ],
 
-			'0.0' => 0,
-			'1.0' => 1,
-			'4.2' => 4.2,
-			'0.1' => 0.1,
-			'90.01' => 90.01,
-			'-1.0' => -1,
-			'-4.2' => -4.2,
+			[ '0.0', new NumberValue( 0.0 ) ],
+			[ '1.0', new NumberValue( 1.0 ) ],
+			[ '4.2', new NumberValue( 4.2 ) ],
+			[ '0.1', new NumberValue( 0.1 ) ],
+			[ '90.01', new NumberValue( 90.01 ) ],
+			[ '-1.0', new NumberValue( -1.0 ) ],
+			[ '-4.2', new NumberValue( -4.2 ) ],
 		];
-
-		foreach ( $valid as $value => $expected ) {
-			// Because PHP turns them into ints/floats using black magic
-			$value = (string)$value;
-
-			// Because 1 is an int but will come out as a float
-			$expected = (float)$expected;
-
-			$expected = new NumberValue( $expected );
-			$argLists[] = [ $value, $expected ];
-		}
-
-		return $argLists;
 	}
 
 	/**

--- a/tests/ValueParsers/IntParserTest.php
+++ b/tests/ValueParsers/IntParserTest.php
@@ -7,6 +7,7 @@ use ValueParsers\IntParser;
 
 /**
  * @covers ValueParsers\IntParser
+ * @covers ValueParsers\StringValueParser
  *
  * @group ValueParsers
  * @group DataValueExtensions
@@ -29,27 +30,15 @@ class IntParserTest extends StringValueParserTest {
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
-		$argLists = [];
-
-		$valid = [
-			'0' => 0,
-			'1' => 1,
-			'42' => 42,
-			'01' => 01,
-			'9001' => 9001,
-			'-1' => -1,
-			'-42' => -42,
+		return [
+			[ '0', new NumberValue( 0 ) ],
+			[ '1', new NumberValue( 1 ) ],
+			[ '42', new NumberValue( 42 ) ],
+			[ '01', new NumberValue( 01 ) ],
+			[ '9001', new NumberValue( 9001 ) ],
+			[ '-1', new NumberValue( -1 ) ],
+			[ '-42', new NumberValue( -42 ) ],
 		];
-
-		foreach ( $valid as $value => $expected ) {
-			// Because PHP turns them into ints using black magic
-			$value = (string)$value;
-
-			$expected = new NumberValue( $expected );
-			$argLists[] = [ $value, $expected ];
-		}
-
-		return $argLists;
 	}
 
 	/**

--- a/tests/ValueParsers/NullParserTest.php
+++ b/tests/ValueParsers/NullParserTest.php
@@ -30,43 +30,28 @@ class NullParserTest extends ValueParserTestBase {
 	 * @see ValueParserTestBase::validInputProvider
 	 */
 	public function validInputProvider() {
-		$argLists = [];
-
-		$values = [
-			'42',
-			42,
-			false,
-			[],
-			'ohi there!',
-			null,
-			4.2,
+		return [
+			[ '42', new UnknownValue( '42' ) ],
+			[ 42, new UnknownValue( 42 ) ],
+			[ false, new UnknownValue( false ) ],
+			[ [], new UnknownValue( [] ) ],
+			[ 'ohi there!', new UnknownValue( 'ohi there!' ) ],
+			[ null, new UnknownValue( null ) ],
+			[ 4.2, new UnknownValue( 4.2 ) ],
 		];
-
-		foreach ( $values as $value ) {
-			$argLists[] = [
-				$value,
-				new UnknownValue( $value )
-			];
-		}
-
-		return $argLists;
 	}
 
 	/**
 	 * @see ValueParserTestBase::invalidInputProvider
 	 */
 	public function invalidInputProvider() {
-		return [
-			[ null ]
-		];
+		return [ [ null ] ];
 	}
 
 	/**
 	 * @see ValueParserTestBase::testParseWithInvalidInputs
 	 *
 	 * @dataProvider invalidInputProvider
-	 * @param mixed $value
-	 * @param ValueParser|null $parser
 	 */
 	public function testParseWithInvalidInputs( $value, ValueParser $parser = null ) {
 		$this->markTestSkipped( 'NullParser has no invalid inputs' );

--- a/tests/ValueParsers/StringValueParserTest.php
+++ b/tests/ValueParsers/StringValueParserTest.php
@@ -33,21 +33,11 @@ abstract class StringValueParserTest extends ValueParserTestBase {
 	}
 
 	public function testSetAndGetOptions() {
-		/**
-		 * @var StringValueParser $parser
-		 */
+		/** @var StringValueParser $parser */
 		$parser = $this->getInstance();
-
-		$parser->setOptions( new ParserOptions() );
-
-		$this->assertEquals( new ParserOptions(), $parser->getOptions() );
-
 		$options = new ParserOptions();
-		$options->setOption( '~=[,,_,,]:3', '~=[,,_,,]:3' );
-
 		$parser->setOptions( $options );
-
-		$this->assertEquals( $options, $parser->getOptions() );
+		$this->assertSame( $options, $parser->getOptions() );
 	}
 
 }


### PR DESCRIPTION
This tests simplifies the syntax of existing `@dataProvider`s and adds a bunch of missing test cases to maximize code coverage. With this, only two protected methods in StringValueParser are uncovered.

This conflicts slightly with #51 because in #51 there are no tests for `newFromArray`. I believe it's fine to merge the two patches in whatever order you prefer.
