### PR TITLE
Add type hints to Mono/MultilingualTextValue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",
 		"ockcyp/covers-validator": "~0.4",
-		"squizlabs/php_codesniffer": "~2.5",
-		"mediawiki/mediawiki-codesniffer": "~0.5"
+		"mediawiki/mediawiki-codesniffer": ">=0.4 <0.8"
 	},
 	"extra": {
 		"branch-alias": {

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -127,7 +127,7 @@ class MonolingualTextValue extends DataValueObject {
 	 *
 	 * @param string[] $data
 	 *
-	 * @return static
+	 * @return self
 	 * @throws IllegalValueException
 	 */
 	public static function newFromArray( array $data ) {

--- a/src/DataValues/MultilingualTextValue.php
+++ b/src/DataValues/MultilingualTextValue.php
@@ -124,19 +124,19 @@ class MultilingualTextValue extends DataValueObject {
 	 *
 	 * @since 0.1
 	 *
-	 * @param mixed $data
+	 * @param array[] $data
 	 *
-	 * @throws IllegalValueException if $data is not an array.
-	 * @return static
+	 * @throws IllegalValueException if $data is not an array of arrays.
+	 * @return self
 	 */
-	public static function newFromArray( $data ) {
-		if ( !is_array( $data ) ) {
-			throw new IllegalValueException( "array expected" );
-		}
-
+	public static function newFromArray( array $data ) {
 		$values = [];
 
 		foreach ( $data as $monolingualValue ) {
+			if ( !is_array( $monolingualValue ) ) {
+				throw new IllegalValueException( '$data must be an array of arrays' );
+			}
+
 			$values[] = MonolingualTextValue::newFromArray( $monolingualValue );
 		}
 


### PR DESCRIPTION
This follow-up is now required because of the change made in #50.
- `newFromArray` is not in an interface, but assumed to be there when called from `DataValueDeserializer`. No other assumption is made about the parameter. Having the strict type hint is not different from the manual check-and-throw.
- `static` is a keyword not all IDEs and analysis tools know. Common practice is to use `self`, and we do this everywhere, except for very few mistakes like this one.
