### PR TITLE
Add PHPCS

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,6 +27,9 @@
 		"data-values/data-values": "~1.0|~0.1",
 		"data-values/interfaces": "~0.2.0|~0.1.5"
 	},
+	"require-dev": {
+		"mediawiki/mediawiki-codesniffer": "~0.5"
+	},
 	"extra": {
 		"branch-alias": {
 			"dev-master": "0.3.x-dev"
@@ -46,6 +49,9 @@
 		]
 	},
 	"scripts": {
+		"phpcs": [
+			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
+		],
 		"test": [
 			"composer validate --no-interaction",
 			"phpunit --coverage-php /dev/null"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="DataValuesCommon">
+	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
+	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+		<exclude name="Generic.Arrays.DisallowLongArraySyntax" />
+		<exclude name="PSR2.Methods.MethodDeclaration" />
+	</rule>
+
+	<rule ref="Generic.Files.LineLength">
+		<properties>
+			<property name="lineLimit" value="124" />
+		</properties>
+	</rule>
+
+	<arg name="extensions" value="php" />
+</ruleset>

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -72,8 +72,7 @@ abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
 			}
 
 			$this->assertTrue( $expected->equals( $actual ), $msg );
-		}
-		else {
+		} else {
 			$this->assertEquals( $expected, $actual );
 		}
 	}


### PR DESCRIPTION
This is the most minimal patch I can think of to add PHPCS support to this component. I'm reusing the predefined MediaWiki rule set with no additional rules (for now).