### PR TITLE
fix typo "recognitzed" -> "recognized"

### DIFF
--- a/src/ValueParsers/DispatchingValueParser.php
+++ b/src/ValueParsers/DispatchingValueParser.php
@@ -62,7 +62,7 @@ class DispatchingValueParser implements ValueParser {
 		}
 
 		throw new ParseException(
-			'The value is not recognitzed by the configured parsers',
+			'The value is not recognized by the configured parsers',
 			$value,
 			$this->format
 		);


### PR DESCRIPTION
I bumped into this in `wbparsevalue`, and it took me an hour to find where it comes from.