### PR TITLE
Convert DataValues Common to extension registration

### DIFF
--- a/Common.php
+++ b/Common.php
@@ -17,16 +17,6 @@ if ( defined( 'DATAVALUES_COMMON_VERSION' ) ) {
 
 define( 'DATAVALUES_COMMON_VERSION', '0.3.1' );
 
-if ( defined( 'MEDIAWIKI' ) ) {
-	$GLOBALS['wgExtensionCredits']['datavalues'][] = array(
-		'path' => __DIR__,
-		'name' => 'DataValues Common',
-		'version' => DATAVALUES_COMMON_VERSION,
-		'author' => array(
-			'[https://www.mediawiki.org/wiki/User:Jeroen_De_Dauw Jeroen De Dauw]'
-		),
-		'url' => 'https://github.com/DataValues/Common',
-		'description' => 'Contains common implementations of the interfaces defined by DataValuesInterfaces',
-		'license-name' => 'GPL-2.0+'
-	);
+if ( defined( 'MEDIAWIKI' ) && function_exists( 'wfLoadExtension' ) ) {
+	wfLoadExtension( 'DataValuesCommon', __DIR__ . '/mediawiki-extension.json' );
 }

--- a/mediawiki-extension.json
+++ b/mediawiki-extension.json
@@ -1,0 +1,13 @@
+{
+	"name": "DataValues Common",
+	"version": "0.3.1",
+	"author": [
+		"[https://www.mediawiki.org/wiki/User:Jeroen_De_Dauw Jeroen De Dauw]"
+	],
+	"url": "https://github.com/DataValues/Common",
+	"description": "Contains common implementations of the interfaces defined by DataValuesInterfaces",
+	"license-name": "GPL-2.0+",
+	"type": "datavalues",
+	"load_composer_autoloader": true,
+	"manifest_version": 1
+}


### PR DESCRIPTION
Re-submission of #56. The style is identical to [what we do in Wikibase DataModel](https://github.com/wmde/WikibaseDataModel/blob/master/WikibaseDataModel.php) and other libraries that are not really MediaWiki extensions, but optionally use MediaWiki's extension registration mechanism.