### PR TITLE
More strict version number range for MediaWiki CodeSniffer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",
 		"ockcyp/covers-validator": "~0.4",
-		"squizlabs/php_codesniffer": "~2.5",
-		"mediawiki/mediawiki-codesniffer": "~0.5"
+		"mediawiki/mediawiki-codesniffer": ">=0.4 <0.8"
 	},
 	"extra": {
 		"branch-alias": {


### PR DESCRIPTION
Same as https://github.com/DataValues/Geo/pull/102.

This is now the same as in Wikibase.git. We do not want this to automatically pull in currently unreleased versions that might contain breaking changes (0.8, 0.9, and so on).