### PR TITLE
Use Wikibase's CodeSniffer instead of MediaWiki's

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require-dev": {
 		"phpunit/phpunit": "~4.8",
 		"ockcyp/covers-validator": "~0.4",
-		"mediawiki/mediawiki-codesniffer": "0.7.2"
+		"wikibase/wikibase-codesniffer": "^0.1.0"
 	},
 	"extra": {
 		"branch-alias": {

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,43 +1,12 @@
 <?xml version="1.0"?>
 <ruleset name="DataValuesCommon">
-	<!-- See https://github.com/wikimedia/mediawiki-tools-codesniffer/blob/master/MediaWiki/ruleset.xml -->
-	<rule ref="vendor/mediawiki/mediawiki-codesniffer/MediaWiki">
+	<rule ref="./vendor/wikibase/wikibase-codesniffer/Wikibase">
 		<exclude name="PSR2.Methods.MethodDeclaration" />
 	</rule>
 
-	<rule ref="Generic.ControlStructures" />
 	<rule ref="Generic.Files.LineLength">
 		<properties>
 			<property name="lineLimit" value="124" />
 		</properties>
 	</rule>
-	<rule ref="Generic.PHP.CharacterBeforePHPOpeningTag" />
-
-	<rule ref="PSR1" />
-	<rule ref="PSR1.Methods.CamelCapsMethodName.NotCamelCaps">
-		<!-- Exclude test methods like "testGivenInvalidInput_methodThrowsException". -->
-		<exclude-pattern>tests*Test*\.php</exclude-pattern>
-	</rule>
-
-	<rule ref="PSR2.Files" />
-
-	<rule ref="Squiz.Classes.DuplicateProperty" />
-	<rule ref="Squiz.Classes.SelfMemberReference" />
-	<rule ref="Squiz.ControlStructures.ControlSignature" />
-	<rule ref="Squiz.Functions.FunctionDuplicateArgument" />
-	<rule ref="Squiz.Functions.GlobalFunction" />
-	<rule ref="Squiz.Scope" />
-	<rule ref="Squiz.WhiteSpace.FunctionSpacing">
-		<properties>
-			<property name="spacing" value="1" />
-		</properties>
-	</rule>
-	<rule ref="Squiz.WhiteSpace.OperatorSpacing">
-		<properties>
-			<property name="ignoreNewlines" value="true" />
-		</properties>
-	</rule>
-
-	<arg name="extensions" value="php" />
-	<arg name="encoding" value="utf8" />
 </ruleset>


### PR DESCRIPTION
This is a test for the new https://github.com/wmde/WikibaseCodeSniffer. Note that nothing is left in the local phpcs.xml rule set, except very few actual exceptions from the base rule set.