### PR TITLE
Remove bad array type hint from …::newFromArray constructors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: php
 
+dist: trusty
+
 php:
   - 5.5
   - 5.6

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
 		"phpunit/phpunit": "~4.8",
 		"ockcyp/covers-validator": "~0.4",
 		"squizlabs/php_codesniffer": "~2.5",
-		"mediawiki/mediawiki-codesniffer": "~0.5"
+		"mediawiki/mediawiki-codesniffer": "0.7.2"
 	},
 	"extra": {
 		"branch-alias": {
@@ -53,12 +53,12 @@
 	},
 	"scripts": {
 		"cs": [
-			"vendor/bin/phpcs src/* tests/* --standard=phpcs.xml -sp"
+			"phpcs src/* tests/* --standard=phpcs.xml -sp"
 		],
 		"test": [
-			"composer validate --no-interaction",
-			"vendor/bin/covers-validator",
-			"vendor/bin/phpunit"
+			"@validate --no-interaction",
+			"covers-validator",
+			"phpunit"
 		],
 		"ci": [
 			"@test",

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -23,8 +23,6 @@ class MonolingualTextValue extends DataValueObject {
 	private $text;
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param string $languageCode
 	 * @param string $text
 	 *
@@ -90,8 +88,6 @@ class MonolingualTextValue extends DataValueObject {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getText() {
@@ -99,8 +95,6 @@ class MonolingualTextValue extends DataValueObject {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return string
 	 */
 	public function getLanguageCode() {
@@ -120,17 +114,22 @@ class MonolingualTextValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance of the DataValue from the provided data.
-	 * This can round-trip with @see getArrayValue
+	 * Constructs a new instance from the provided data. Required for @see DataValueDeserializer.
+	 * This is expected to round-trip with @see getArrayValue.
 	 *
-	 * @since 0.1
+	 * @deprecated since 0.3.2. Static DataValue::newFromArray constructors like this are
+	 *  underspecified (not in the DataValue interface), and misleadingly named (should be named
+	 *  newFromArrayValue). Instead, use DataValue builder callbacks in @see DataValueDeserializer.
 	 *
-	 * @param string[] $data
+	 * @param mixed $data Warning! Even if this is expected to be a value as returned by
+	 *  @see getArrayValue, callers of this specific newFromArray implementation can not guarantee
+	 *  this. This is not even guaranteed to be an array!
 	 *
-	 * @return static
-	 * @throws IllegalValueException
+	 * @throws IllegalValueException if $data is not in the expected format. Subclasses of
+	 *  InvalidArgumentException are expected and properly handled by @see DataValueDeserializer.
+	 * @return self
 	 */
-	public static function newFromArray( array $data ) {
+	public static function newFromArray( $data ) {
 		self::requireArrayFields( $data, [ 'language', 'text' ] );
 
 		return new static( $data['language'], $data['text'] );

--- a/src/DataValues/MultilingualTextValue.php
+++ b/src/DataValues/MultilingualTextValue.php
@@ -20,8 +20,6 @@ class MultilingualTextValue extends DataValueObject {
 	private $texts = [];
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param MonolingualTextValue[] $monolingualValues
 	 *
 	 * @throws IllegalValueException
@@ -81,8 +79,6 @@ class MultilingualTextValue extends DataValueObject {
 	/**
 	 * Returns the texts as an array of monolingual text values.
 	 *
-	 * @since 0.1
-	 *
 	 * @return MonolingualTextValue[]
 	 */
 	public function getTexts() {
@@ -118,16 +114,20 @@ class MultilingualTextValue extends DataValueObject {
 	}
 
 	/**
-	 * Constructs a new instance of the DataValue from the provided data.
-	 * This can round-trip with
-	 * @see   getArrayValue
+	 * Constructs a new instance from the provided data. Required for @see DataValueDeserializer.
+	 * This is expected to round-trip with @see getArrayValue.
 	 *
-	 * @since 0.1
+	 * @deprecated since 0.3.2. Static DataValue::newFromArray constructors like this are
+	 *  underspecified (not in the DataValue interface), and misleadingly named (should be named
+	 *  newFromArrayValue). Instead, use DataValue builder callbacks in @see DataValueDeserializer.
 	 *
-	 * @param mixed $data
+	 * @param mixed $data Warning! Even if this is expected to be a value as returned by
+	 *  @see getArrayValue, callers of this specific newFromArray implementation can not guarantee
+	 *  this. This is not even guaranteed to be an array!
 	 *
-	 * @throws IllegalValueException if $data is not an array.
-	 * @return static
+	 * @throws IllegalValueException if $data is not in the expected format. Subclasses of
+	 *  InvalidArgumentException are expected and properly handled by @see DataValueDeserializer.
+	 * @return self
 	 */
 	public static function newFromArray( $data ) {
 		if ( !is_array( $data ) ) {


### PR DESCRIPTION
The bad `array` type hint was added with #50, but never released. So this does not need an immediate release now.

[Bug: T168681](https://phabricator.wikimedia.org/T168681)