### PR TITLE
Improve the abstract StringValueParser documentation

### DIFF
--- a/src/ValueParsers/StringValueParser.php
+++ b/src/ValueParsers/StringValueParser.php
@@ -6,7 +6,10 @@ use InvalidArgumentException;
 use RuntimeException;
 
 /**
- * ValueParser that parses the string representation of something.
+ * Basic implementation for DataValue parsers that share one or more of the following aspects:
+ * - The provided input must be a string.
+ * - The parser utilizes ParserOptions.
+ * - The parser utilizes a "lang" option, which defaults to "en".
  *
  * @since 0.1
  *
@@ -16,15 +19,11 @@ use RuntimeException;
 abstract class StringValueParser implements ValueParser {
 
 	/**
-	 * @since 0.1
-	 *
 	 * @var ParserOptions
 	 */
 	protected $options;
 
 	/**
-	 * @since 0.1
-	 *
 	 * @param ParserOptions|null $options
 	 */
 	public function __construct( ParserOptions $options = null ) {
@@ -36,10 +35,10 @@ abstract class StringValueParser implements ValueParser {
 	/**
 	 * @see ValueParser::parse
 	 *
-	 * @param mixed $value
+	 * @param string $value
 	 *
 	 * @return mixed
-	 * @throws ParseException
+	 * @throws ParseException if the provided value is not a string
 	 */
 	public function parse( $value ) {
 		if ( is_string( $value ) ) {
@@ -52,26 +51,17 @@ abstract class StringValueParser implements ValueParser {
 	/**
 	 * Parses the provided string and returns the result.
 	 *
-	 * @since 0.1
-	 *
 	 * @param string $value
 	 *
 	 * @return mixed
 	 */
 	protected abstract function stringParse( $value );
 
-	/**
-	 * @since 0.1
-	 *
-	 * @param ParserOptions $options
-	 */
 	public function setOptions( ParserOptions $options ) {
 		$this->options = $options;
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return ParserOptions
 	 */
 	public function getOptions() {
@@ -80,8 +70,6 @@ abstract class StringValueParser implements ValueParser {
 
 	/**
 	 * Shortcut to $this->options->getOption.
-	 *
-	 * @since 0.1
 	 *
 	 * @param string $option
 	 *
@@ -95,8 +83,6 @@ abstract class StringValueParser implements ValueParser {
 	/**
 	 * Shortcut to $this->options->requireOption.
 	 *
-	 * @since 0.1
-	 *
 	 * @param string $option
 	 *
 	 * @throws RuntimeException
@@ -107,8 +93,6 @@ abstract class StringValueParser implements ValueParser {
 
 	/**
 	 * Shortcut to $this->options->defaultOption.
-	 *
-	 * @since 0.1
 	 *
 	 * @param string $option
 	 * @param mixed $default

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -21,29 +21,21 @@ use ValueParsers\ValueParser;
 abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return array[]
 	 */
 	public abstract function validInputProvider();
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return array[]
 	 */
 	public abstract function invalidInputProvider();
 
 	/**
-	 * @since 0.1
-	 *
 	 * @return ValueParser
 	 */
 	protected abstract function getInstance();
 
 	/**
-	 * @since 0.1
-	 *
 	 * @dataProvider validInputProvider
 	 * @param mixed $value
 	 * @param mixed $expected
@@ -78,8 +70,6 @@ abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
 	}
 
 	/**
-	 * @since 0.1
-	 *
 	 * @dataProvider invalidInputProvider
 	 * @param mixed $value
 	 * @param ValueParser|null $parser
@@ -95,8 +85,6 @@ abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * Returns if the result of the parsing process should be checked to be a DataValue.
-	 *
-	 * @since 0.1
 	 *
 	 * @return bool
 	 */


### PR DESCRIPTION
I'm also removing duplicate `@since` tags that don't add anything but repeating when the class was introduced.