### PR TITLE
Fix StringParser::parse not throwing expected ParseException

### DIFF
--- a/src/ValueParsers/StringParser.php
+++ b/src/ValueParsers/StringParser.php
@@ -3,7 +3,6 @@
 namespace ValueParsers;
 
 use DataValues\StringValue;
-use InvalidArgumentException;
 use ValueParsers\Normalizers\NullStringNormalizer;
 use ValueParsers\Normalizers\StringNormalizer;
 
@@ -34,12 +33,12 @@ class StringParser implements ValueParser {
 	 *
 	 * @param string $value
 	 *
-	 * @throws InvalidArgumentException if $value is not a string
+	 * @throws ParseException if the provided value is not a string
 	 * @return StringValue
 	 */
 	public function parse( $value ) {
 		if ( !is_string( $value ) ) {
-			throw new InvalidArgumentException( 'Parameter $value must be a string' );
+			throw new ParseException( 'Parameter $value must be a string' );
 		}
 
 		$value = $this->normalizer->normalize( $value );

--- a/tests/ValueParsers/StringParserTest.php
+++ b/tests/ValueParsers/StringParserTest.php
@@ -5,6 +5,7 @@ namespace ValueParsers\Test;
 use DataValues\DataValue;
 use DataValues\StringValue;
 use ValueParsers\Normalizers\StringNormalizer;
+use ValueParsers\ParseException;
 use ValueParsers\StringParser;
 
 /**
@@ -56,7 +57,7 @@ class StringParserTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testGivenNonString_parseThrowsException( $input ) {
 		$parser = new StringParser();
-		$this->setExpectedException( 'InvalidArgumentException' );
+		$this->setExpectedException( ParseException::class );
 		$parser->parse( $input );
 	}
 


### PR DESCRIPTION
I would go so far and count this as a bug. No caller of a ValueParser expects this exception. What they expect and properly report to the user is a ParseException.

~~I can see this is not documented in the interface, but~~ (fixed with https://github.com/DataValues/Interfaces/pull/41) is what almost all existing code (callers as well as implementations) does.

Luckily this is entirely irrelevant in production. The way this method is called guarantees the provided value is a string. So this exception was never thrown. I would like to clean up this inconsistency anyway.