### PR TITLE
Document keys of MultilingualTextValue::getTexts()

### DIFF
--- a/src/DataValues/MultilingualTextValue.php
+++ b/src/DataValues/MultilingualTextValue.php
@@ -77,7 +77,8 @@ class MultilingualTextValue extends DataValueObject {
 	}
 
 	/**
-	 * Returns the texts as an array of monolingual text values.
+	 * Returns the texts as an array of monolingual text values,
+	 * with the language codes as array keys.
 	 *
 	 * @return MonolingualTextValue[]
 	 */


### PR DESCRIPTION
The useful detail that texts are indexed by language codes was not previously documented.

---

I plan to rely on this detail in WikibaseQualityConstraints soon (see [gerrit change 407656](https://gerrit.wikimedia.org/r/407656)), so I would feel more comfortable if this was explicitly documented :)