### PR TITLE
Release 0.4.3

### DIFF
--- a/Common.php
+++ b/Common.php
@@ -15,4 +15,4 @@ if ( defined( 'DATAVALUES_COMMON_VERSION' ) ) {
 	return 1;
 }
 
-define( 'DATAVALUES_COMMON_VERSION', '0.4.2' );
+define( 'DATAVALUES_COMMON_VERSION', '0.4.3' );

--- a/README.md
+++ b/README.md
@@ -49,6 +49,18 @@ DataValues Common has been written by the Wikidata team, as [Wikimedia Germany]
 
 ## Release notes
 
+### 0.4.3 (2019-06-28)
+
+* Fixed typo in error message in `DispatchingValueParser`
+
+### 0.4.2 (2018-08-16)
+
+* The component can now be installed together with DataValues 2.x
+
+### 0.4.1 (2018-08-09)
+
+* Fixed version number not updated before.
+
 ### 0.4.0 (2017-08-09)
 
 * Removed MediaWiki integration


### PR DESCRIPTION
This is a bit of cheating, as the right (tm) thing to do would be to drop support for PHP <5.6 and release it as 0.5. But I'd rather cheat a bit here, and have 1.0.0 as a next release ever done.