### PR TITLE
Make tests package private

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,10 @@ employees for the [Wikidata project](https://wikidata.org/).
 
 ### 1.0.0 (dev)
 
-* Added `TrimmingStringNormalizer`
 * Removed the `DATAVALUES_COMMON_VERSION` constant
+* Classes in the `ValueParsers\Test` namespace are now package private. Notably `ValueParserTestBase` and `StringValueParserTest`
 * The `StringFormatter` constructor does not accept options any more
+* Added `TrimmingStringNormalizer`
 
 ### 0.4.2 (2018-08-16)
 

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,9 @@
 			"DataValues\\": "src/DataValues/",
 			"ValueFormatters\\": "src/ValueFormatters/",
 			"ValueParsers\\": "src/ValueParsers/"
-		},
+		}
+	},
+	"autoload-dev": {
 		"classmap": [
 			"tests/ValueParsers"
 		]


### PR DESCRIPTION
Allows for https://github.com/DataValues/Common/pull/84

Wikibase Repo has 3 usages of StringValueParserTest:
https://github.com/wikimedia/mediawiki-extensions-Wikibase/search?q=StringValueParserTest

These can easily be fixed by using a copy of the class
(or better yet: refactoring away from this inheritance abuse pattern).