### PR TITLE
Update PHP, PHPUnit, DataValues, Interfaces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ language: php
 dist: trusty
 
 php:
-  - 5.5
-  - 5.6
-  - 7
-  - 7.1
   - 7.2
   - 7.3
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ employees for the [Wikidata project](https://wikidata.org/).
 ### 1.0.0 (dev)
 
 * Removed the `DATAVALUES_COMMON_VERSION` constant
-* Removed `getCopy` and `getSortKey` methods from `DataValue` implementations
+* Deprecated `getSortKey` methods from `DataValue` implementations
 * Classes in the `ValueParsers\Test` namespace are now package private. Notably `ValueParserTestBase` and `StringValueParserTest`
 * The `StringFormatter` constructor does not accept options any more
 * `StringParser::parse` now throws a `ParseException` instead of an `InvalidArgumentException`

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ employees for the [Wikidata project](https://wikidata.org/).
 ### 1.0.0 (dev)
 
 * Removed the `DATAVALUES_COMMON_VERSION` constant
+* Removed `getCopy` and `getSortKey` methods from `DataValue` implementations
 * Classes in the `ValueParsers\Test` namespace are now package private. Notably `ValueParserTestBase` and `StringValueParserTest`
 * The `StringFormatter` constructor does not accept options any more
 * Added `TrimmingStringNormalizer`

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ employees for the [Wikidata project](https://wikidata.org/).
 * Classes in the `ValueParsers\Test` namespace are now package private. Notably `ValueParserTestBase` and `StringValueParserTest`
 * The `StringFormatter` constructor does not accept options any more
 * Added `TrimmingStringNormalizer`
+* Updated minimal required PHP version from 5.5.9 to 7.2
 
 ### 0.4.2 (2018-08-16)
 

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=5.5.9",
+		"php": ">=7.2.0",
 		"data-values/data-values": "~2.0|~1.0|~0.1",
 		"data-values/interfaces": "~0.2.0"
 	},

--- a/composer.json
+++ b/composer.json
@@ -24,12 +24,12 @@
 	},
 	"require": {
 		"php": ">=7.2.0",
-		"data-values/data-values": "~2.0|~1.0|~0.1",
-		"data-values/interfaces": "~0.2.0"
+		"data-values/data-values": "~3.0|~2.0|~1.0|~0.1",
+		"data-values/interfaces": "~1.0|~0.2.0"
 	},
 	"require-dev": {
-		"ockcyp/covers-validator": "~0.4",
-		"phpunit/phpunit": "~4.8",
+		"ockcyp/covers-validator": "~1.2",
+		"phpunit/phpunit": "~8.0",
 		"wikibase/wikibase-codesniffer": "^0.1.0"
 	},
 	"extra": {

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -69,6 +69,17 @@ class MonolingualTextValue extends DataValueObject {
 	}
 
 	/**
+	 * @deprecated Kept for compatibility with older DataValues versions.
+	 * Do not use.
+	 *
+	 * @return string
+	 */
+	public function getSortKey() {
+		// TODO: we might want to re-think this key. Perhaps the language should simply be omitted.
+		return $this->languageCode . $this->text;
+	}
+
+	/**
 	 * @see DataValue::getValue
 	 *
 	 * @return self

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -69,16 +69,6 @@ class MonolingualTextValue extends DataValueObject {
 	}
 
 	/**
-	 * @see DataValue::getSortKey
-	 *
-	 * @return string
-	 */
-	public function getSortKey() {
-		// TODO: we might want to re-think this key. Perhaps the language should simply be omitted.
-		return $this->languageCode . $this->text;
-	}
-
-	/**
 	 * @see DataValue::getValue
 	 *
 	 * @return self

--- a/src/DataValues/MultilingualTextValue.php
+++ b/src/DataValues/MultilingualTextValue.php
@@ -68,6 +68,16 @@ class MultilingualTextValue extends DataValueObject {
 	}
 
 	/**
+	 * @deprecated Kept for compatibility with older DataValues versions.
+	 * Do not use.
+	 *
+	 * @return string|float|int
+	 */
+	public function getSortKey() {
+		return empty( $this->texts ) ? '' : reset( $this->texts )->getSortKey();
+	}
+
+	/**
 	 * Returns the texts as an array of monolingual text values,
 	 * with the language codes as array keys.
 	 *

--- a/src/DataValues/MultilingualTextValue.php
+++ b/src/DataValues/MultilingualTextValue.php
@@ -68,15 +68,6 @@ class MultilingualTextValue extends DataValueObject {
 	}
 
 	/**
-	 * @see DataValue::getSortKey
-	 *
-	 * @return string|float|int
-	 */
-	public function getSortKey() {
-		return empty( $this->texts ) ? '' : reset( $this->texts )->getSortKey();
-	}
-
-	/**
 	 * Returns the texts as an array of monolingual text values,
 	 * with the language codes as array keys.
 	 *

--- a/tests/DataValues/MonolingualTextValueTest.php
+++ b/tests/DataValues/MonolingualTextValueTest.php
@@ -23,7 +23,6 @@ class MonolingualTextValueTest extends TestCase {
 	public function testGetters() {
 		$value = new MonolingualTextValue( 'en', 'foo' );
 		$this->assertSame( 'monolingualtext', $value->getType() );
-		$this->assertSame( 'enfoo', $value->getSortKey() );
 		$this->assertSame( 'foo', $value->getText() );
 		$this->assertSame( 'en', $value->getLanguageCode() );
 	}

--- a/tests/DataValues/MonolingualTextValueTest.php
+++ b/tests/DataValues/MonolingualTextValueTest.php
@@ -4,6 +4,8 @@ namespace DataValues\Tests;
 
 use DataValues\IllegalValueException;
 use DataValues\MonolingualTextValue;
+use Exception;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @covers \DataValues\MonolingualTextValue
@@ -16,22 +18,38 @@ use DataValues\MonolingualTextValue;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-class MonolingualTextValueTest extends DataValueTest {
+class MonolingualTextValueTest extends TestCase {
 
-	/**
-	 * @see DataValueTest::getClass
-	 *
-	 * @return string
-	 */
-	public function getClass() {
-		return MonolingualTextValue::class;
+	public function testGetters() {
+		$value = new MonolingualTextValue( 'en', 'foo' );
+		$this->assertSame( 'monolingualtext', $value->getType() );
+		$this->assertSame( 'enfoo', $value->getSortKey() );
+		$this->assertSame( 'foo', $value->getText() );
+		$this->assertSame( 'en', $value->getLanguageCode() );
 	}
 
-	public function validConstructorArgumentsProvider() {
-		return [
-			[ 'en', 'foo' ],
-			[ 'en', ' foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz foo bar baz ' ],
-		];
+	public function testArrayAndEquals() {
+		$value = new MonolingualTextValue( 'en', 'foo' );
+		$array = $value->getArrayValue();
+		$value2 = MonolingualTextValue::newFromArray( $array );
+		$this->assertTrue( $value->equals( $value2 ) );
+		$this->assertEquals( $value, $value2 );
+	}
+
+	public function testSerialize() {
+		$value = new MonolingualTextValue( 'en', 'foo' );
+		$serialization = serialize( $value );
+		$value2 = unserialize( $serialization );
+		$this->assertEquals( $value, $value2 );
+	}
+
+	/**
+	 * @dataProvider invalidConstructorArgumentsProvider
+	 */
+	public function testConstructorWithInvalidArguments( $languageCode, $text ) {
+		$this->expectException( Exception::class );
+
+		$dataItem = new MonolingualTextValue( $languageCode, $text );
 	}
 
 	public function invalidConstructorArgumentsProvider() {
@@ -49,17 +67,11 @@ class MonolingualTextValueTest extends DataValueTest {
 		];
 	}
 
-	public function testNewFromArray() {
-		$array = [ 'text' => 'foo', 'language' => 'en' ];
-		$value = MonolingualTextValue::newFromArray( $array );
-		$this->assertSame( $array, $value->getArrayValue() );
-	}
-
 	/**
 	 * @dataProvider invalidArrayProvider
 	 */
 	public function testNewFromArrayWithInvalidArray( array $array ) {
-		$this->setExpectedException( IllegalValueException::class );
+		$this->expectException( IllegalValueException::class );
 		MonolingualTextValue::newFromArray( $array );
 	}
 
@@ -72,25 +84,6 @@ class MonolingualTextValueTest extends DataValueTest {
 			[ [ 'language' => 'en' ] ],
 			[ [ 'text' => 'foo' ] ],
 		];
-	}
-
-	public function testGetSortKey() {
-		$value = new MonolingualTextValue( 'en', 'foo' );
-		$this->assertSame( 'enfoo', $value->getSortKey() );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 */
-	public function testGetText( MonolingualTextValue $text, array $arguments ) {
-		$this->assertEquals( $arguments[1], $text->getText() );
-	}
-
-	/**
-	 * @dataProvider instanceProvider
-	 */
-	public function testGetLanguageCode( MonolingualTextValue $text, array $arguments ) {
-		$this->assertEquals( $arguments[0], $text->getLanguageCode() );
 	}
 
 }

--- a/tests/DataValues/MonolingualTextValueTest.php
+++ b/tests/DataValues/MonolingualTextValueTest.php
@@ -23,6 +23,7 @@ class MonolingualTextValueTest extends TestCase {
 	public function testGetters() {
 		$value = new MonolingualTextValue( 'en', 'foo' );
 		$this->assertSame( 'monolingualtext', $value->getType() );
+		$this->assertSame( 'enfoo', $value->getSortKey() );
 		$this->assertSame( 'foo', $value->getText() );
 		$this->assertSame( 'en', $value->getLanguageCode() );
 	}

--- a/tests/DataValues/MultilingualTextValueTest.php
+++ b/tests/DataValues/MultilingualTextValueTest.php
@@ -26,6 +26,7 @@ class MultilingualTextValueTest extends TestCase {
 		$monolingualTextValue2 = new MonolingualTextValue( 'de', 'foo' );
 		$value = new MultilingualTextValue( [ $monolingualTextValue1, $monolingualTextValue2 ] );
 		$this->assertSame( 'multilingualtext', $value->getType() );
+		$this->assertSame( 'enfoo', $value->getSortKey() );
 		$this->assertSame(
 			[ 'en' => $monolingualTextValue1, 'de' => $monolingualTextValue2 ],
 			$value->getTexts()
@@ -34,6 +35,7 @@ class MultilingualTextValueTest extends TestCase {
 
 	public function testGetters_empty() {
 		$value = new MultilingualTextValue( [] );
+		$this->assertSame( '', $value->getSortKey() );
 		$this->assertSame( [], $value->getTexts() );
 	}
 

--- a/tests/DataValues/MultilingualTextValueTest.php
+++ b/tests/DataValues/MultilingualTextValueTest.php
@@ -26,7 +26,6 @@ class MultilingualTextValueTest extends TestCase {
 		$monolingualTextValue2 = new MonolingualTextValue( 'de', 'foo' );
 		$value = new MultilingualTextValue( [ $monolingualTextValue1, $monolingualTextValue2 ] );
 		$this->assertSame( 'multilingualtext', $value->getType() );
-		$this->assertSame( 'enfoo', $value->getSortKey() );
 		$this->assertSame(
 			[ 'en' => $monolingualTextValue1, 'de' => $monolingualTextValue2 ],
 			$value->getTexts()
@@ -35,7 +34,6 @@ class MultilingualTextValueTest extends TestCase {
 
 	public function testGetters_empty() {
 		$value = new MultilingualTextValue( [] );
-		$this->assertSame( '', $value->getSortKey() );
 		$this->assertSame( [], $value->getTexts() );
 	}
 

--- a/tests/ValueFormatters/Exceptions/MismatchingDataValueTypeExceptionTest.php
+++ b/tests/ValueFormatters/Exceptions/MismatchingDataValueTypeExceptionTest.php
@@ -3,7 +3,7 @@
 namespace ValueFormatters\Tests\Exceptions;
 
 use Exception;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ValueFormatters\Exceptions\MismatchingDataValueTypeException;
 
 /**
@@ -16,7 +16,7 @@ use ValueFormatters\Exceptions\MismatchingDataValueTypeException;
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Thiemo Kreuz
  */
-class MismatchingDataValueTypeExceptionTest extends PHPUnit_Framework_TestCase {
+class MismatchingDataValueTypeExceptionTest extends TestCase {
 
 	/**
 	 * @dataProvider constructorProvider

--- a/tests/ValueFormatters/StringFormatterTest.php
+++ b/tests/ValueFormatters/StringFormatterTest.php
@@ -4,7 +4,7 @@ namespace ValueFormatters\Test;
 
 use DataValues\StringValue;
 use InvalidArgumentException;
-use ValueFormatters\FormatterOptions;
+use PHPUnit\Framework\TestCase;
 use ValueFormatters\StringFormatter;
 
 /**
@@ -16,22 +16,14 @@ use ValueFormatters\StringFormatter;
  * @license GPL-2.0+
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
-class StringFormatterTest extends ValueFormatterTestBase {
+class StringFormatterTest extends TestCase {
 
-	/**
-	 * @see ValueFormatterTestBase::getInstance
-	 *
-	 * @param FormatterOptions|null $options
-	 *
-	 * @return StringFormatter
-	 */
-	protected function getInstance( FormatterOptions $options = null ) {
-		return new StringFormatter( $options );
+	/** @dataProvider validProvider */
+	public function testValidFormat( StringValue $value, string $expected ) {
+		$formatter = new StringFormatter();
+		$this->assertSame( $expected, $formatter->format( $value ) );
 	}
 
-	/**
-	 * @see ValueFormatterTestBase::validProvider
-	 */
 	public function validProvider() {
 		return [
 			[ new StringValue( 'ice cream' ), 'ice cream' ],
@@ -47,7 +39,7 @@ class StringFormatterTest extends ValueFormatterTestBase {
 	 */
 	public function testInvalidFormat( $value ) {
 		$formatter = new StringFormatter();
-		$this->setExpectedException( InvalidArgumentException::class );
+		$this->expectException( InvalidArgumentException::class );
 		$formatter->format( $value );
 	}
 

--- a/tests/ValueParsers/DispatchingValueParserTest.php
+++ b/tests/ValueParsers/DispatchingValueParserTest.php
@@ -3,8 +3,7 @@
 namespace ValueParsers\Test;
 
 use InvalidArgumentException;
-use PHPUnit_Framework_MockObject_Matcher_Invocation;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ValueParsers\DispatchingValueParser;
 use ValueParsers\ParseException;
 use ValueParsers\ValueParser;
@@ -19,15 +18,10 @@ use ValueParsers\ValueParser;
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class DispatchingValueParserTest extends PHPUnit_Framework_TestCase {
+class DispatchingValueParserTest extends TestCase {
 
-	/**
-	 * @param PHPUnit_Framework_MockObject_Matcher_Invocation $invocation
-	 *
-	 * @return ValueParser
-	 */
-	private function getParser( PHPUnit_Framework_MockObject_Matcher_Invocation $invocation ) {
-		$mock = $this->getMock( ValueParser::class );
+	private function getParser( $invocation ) : ValueParser {
+		$mock = $this->createMock( ValueParser::class );
 
 		$mock->expects( $invocation )
 			->method( 'parse' )
@@ -43,9 +37,9 @@ class DispatchingValueParserTest extends PHPUnit_Framework_TestCase {
 
 	/**
 	 * @dataProvider invalidConstructorArgumentsProvider
-	 * @expectedException InvalidArgumentException
 	 */
 	public function testGivenInvalidConstructorArguments_constructorThrowsException( $parsers, $format ) {
+		$this->expectException( InvalidArgumentException::class );
 		new DispatchingValueParser( $parsers, $format );
 	}
 
@@ -81,7 +75,7 @@ class DispatchingValueParserTest extends PHPUnit_Framework_TestCase {
 			'format'
 		);
 
-		$this->setExpectedException( ParseException::class );
+		$this->expectException( ParseException::class );
 		$parser->parse( 'invalid' );
 	}
 

--- a/tests/ValueParsers/Normalizers/NullStringNormalizerTest.php
+++ b/tests/ValueParsers/Normalizers/NullStringNormalizerTest.php
@@ -4,7 +4,7 @@ namespace ValueParsers\Normalizers\Test;
 
 use DataValues\StringValue;
 use InvalidArgumentException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ValueParsers\Normalizers\NullStringNormalizer;
 
 /**
@@ -16,7 +16,7 @@ use ValueParsers\Normalizers\NullStringNormalizer;
  * @license GPL-2.0+
  * @author Thiemo Kreuz
  */
-class NullStringNormalizerTest extends PHPUnit_Framework_TestCase {
+class NullStringNormalizerTest extends TestCase {
 
 	/**
 	 * @dataProvider stringProvider
@@ -39,7 +39,7 @@ class NullStringNormalizerTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testNormalizeException( $value ) {
 		$normalizer = new NullStringNormalizer();
-		$this->setExpectedException( InvalidArgumentException::class );
+		$this->expectException( InvalidArgumentException::class );
 		$normalizer->normalize( $value );
 	}
 

--- a/tests/ValueParsers/Normalizers/TrimmingStringNormalizerTest.php
+++ b/tests/ValueParsers/Normalizers/TrimmingStringNormalizerTest.php
@@ -3,7 +3,8 @@
 namespace ValueParsers\Normalizers\Test;
 
 use DataValues\StringValue;
-use PHPUnit_Framework_TestCase;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use ValueParsers\Normalizers\TrimmingStringNormalizer;
 
 /**
@@ -15,7 +16,7 @@ use ValueParsers\Normalizers\TrimmingStringNormalizer;
  * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
-class TrimmingStringNormalizerTest extends PHPUnit_Framework_TestCase {
+class TrimmingStringNormalizerTest extends TestCase {
 
 	/**
 	 * @dataProvider stringProvider
@@ -40,7 +41,7 @@ class TrimmingStringNormalizerTest extends PHPUnit_Framework_TestCase {
 	 */
 	public function testNormalizeException( $value ) {
 		$normalizer = new TrimmingStringNormalizer();
-		$this->setExpectedException( 'InvalidArgumentException' );
+		$this->expectException( InvalidArgumentException::class );
 		$normalizer->normalize( $value );
 	}
 

--- a/tests/ValueParsers/StringParserTest.php
+++ b/tests/ValueParsers/StringParserTest.php
@@ -4,6 +4,8 @@ namespace ValueParsers\Test;
 
 use DataValues\DataValue;
 use DataValues\StringValue;
+use InvalidArgumentException;
+use PHPUnit\Framework\TestCase;
 use ValueParsers\Normalizers\StringNormalizer;
 use ValueParsers\StringParser;
 
@@ -16,10 +18,10 @@ use ValueParsers\StringParser;
  * @license GPL-2.0+
  * @author Daniel Kinzler
  */
-class StringParserTest extends \PHPUnit_Framework_TestCase {
+class StringParserTest extends TestCase {
 
 	public function provideParse() {
-		$normalizer = $this->getMock( StringNormalizer::class );
+		$normalizer = $this->createMock( StringNormalizer::class );
 		$normalizer->expects( $this->once() )
 			->method( 'normalize' )
 			->will( $this->returnCallback( function( $value ) {
@@ -56,7 +58,7 @@ class StringParserTest extends \PHPUnit_Framework_TestCase {
 	 */
 	public function testGivenNonString_parseThrowsException( $input ) {
 		$parser = new StringParser();
-		$this->setExpectedException( 'InvalidArgumentException' );
+		$this->expectException( InvalidArgumentException::class );
 		$parser->parse( $input );
 	}
 

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -4,7 +4,7 @@ namespace ValueParsers\Test;
 
 use Comparable;
 use DataValues\DataValue;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use ValueParsers\ParseException;
 use ValueParsers\ValueParser;
 
@@ -19,7 +19,7 @@ use ValueParsers\ValueParser;
  * @license GPL-2.0+
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
-abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
+abstract class ValueParserTestBase extends TestCase {
 
 	/**
 	 * @return array[]
@@ -80,7 +80,7 @@ abstract class ValueParserTestBase extends PHPUnit_Framework_TestCase {
 			$parser = $this->getInstance();
 		}
 
-		$this->setExpectedException( ParseException::class );
+		$this->expectException( ParseException::class );
 		$parser->parse( $value );
 	}
 


### PR DESCRIPTION
Update PHP versions and dependencies on PHPUnit, DataValues and Interfaces. See individual commit messages for details.

I assume this will fail in CI until the new versions of DataValues and Interfaces have been released – I tested this locally by symlinking my Git checkouts into `vendor/data-values/`.