### PR TITLE
Update wikibase-codesniffer to v1.2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
 	"require-dev": {
 		"ockcyp/covers-validator": "~1.2",
 		"phpunit/phpunit": "~8.0",
-		"wikibase/wikibase-codesniffer": "^0.1.0"
+		"wikibase/wikibase-codesniffer": "^1.2.0"
 	},
 	"extra": {
 		"branch-alias": {

--- a/composer.json
+++ b/composer.json
@@ -50,6 +50,9 @@
 		]
 	},
 	"scripts": {
+		"fix": [
+			"phpcbf"
+		],
 		"cs": [
 			"phpcs -p -s"
 		],

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -7,7 +7,7 @@ namespace DataValues;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class MonolingualTextValue extends DataValueObject {

--- a/src/DataValues/MultilingualTextValue.php
+++ b/src/DataValues/MultilingualTextValue.php
@@ -7,7 +7,7 @@ namespace DataValues;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class MultilingualTextValue extends DataValueObject {

--- a/src/DataValues/MultilingualTextValue.php
+++ b/src/DataValues/MultilingualTextValue.php
@@ -27,13 +27,17 @@ class MultilingualTextValue extends DataValueObject {
 	public function __construct( array $monolingualValues ) {
 		foreach ( $monolingualValues as $monolingualValue ) {
 			if ( !( $monolingualValue instanceof MonolingualTextValue ) ) {
-				throw new IllegalValueException( 'Can only construct MultilingualTextValue from MonolingualTextValue objects' );
+				throw new IllegalValueException(
+					'Can only construct MultilingualTextValue from MonolingualTextValue objects'
+				);
 			}
 
 			$languageCode = $monolingualValue->getLanguageCode();
 
 			if ( array_key_exists( $languageCode, $this->texts ) ) {
-				throw new IllegalValueException( 'Can only add a single MonolingualTextValue per language to a MultilingualTextValue' );
+				throw new IllegalValueException(
+					'Can only add a single MonolingualTextValue per language to a MultilingualTextValue'
+				);
 			}
 
 			$this->texts[$languageCode] = $monolingualValue;

--- a/src/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
+++ b/src/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
@@ -8,7 +8,7 @@ use ValueFormatters\FormattingException;
 /**
  * @since 0.2.2
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/src/ValueFormatters/StringFormatter.php
+++ b/src/ValueFormatters/StringFormatter.php
@@ -11,7 +11,7 @@ use InvalidArgumentException;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class StringFormatter implements ValueFormatter {

--- a/src/ValueParsers/BoolParser.php
+++ b/src/ValueParsers/BoolParser.php
@@ -14,7 +14,7 @@ use DataValues\BooleanValue;
  */
 class BoolParser extends StringValueParser {
 
-	const FORMAT_NAME = 'bool';
+	private const FORMAT_NAME = 'bool';
 
 	private static $values = [
 		'yes' => true,

--- a/src/ValueParsers/BoolParser.php
+++ b/src/ValueParsers/BoolParser.php
@@ -9,7 +9,7 @@ use DataValues\BooleanValue;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class BoolParser extends StringValueParser {

--- a/src/ValueParsers/DispatchingValueParser.php
+++ b/src/ValueParsers/DispatchingValueParser.php
@@ -10,7 +10,7 @@ use InvalidArgumentException;
  *
  * @since 0.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class DispatchingValueParser implements ValueParser {

--- a/src/ValueParsers/FloatParser.php
+++ b/src/ValueParsers/FloatParser.php
@@ -9,7 +9,7 @@ use DataValues\NumberValue;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class FloatParser extends StringValueParser {

--- a/src/ValueParsers/FloatParser.php
+++ b/src/ValueParsers/FloatParser.php
@@ -14,7 +14,7 @@ use DataValues\NumberValue;
  */
 class FloatParser extends StringValueParser {
 
-	const FORMAT_NAME = 'float';
+	private const FORMAT_NAME = 'float';
 
 	/**
 	 * @see StringValueParser::stringParse

--- a/src/ValueParsers/IntParser.php
+++ b/src/ValueParsers/IntParser.php
@@ -9,7 +9,7 @@ use DataValues\NumberValue;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class IntParser extends StringValueParser {

--- a/src/ValueParsers/IntParser.php
+++ b/src/ValueParsers/IntParser.php
@@ -14,7 +14,7 @@ use DataValues\NumberValue;
  */
 class IntParser extends StringValueParser {
 
-	const FORMAT_NAME = 'int';
+	private const FORMAT_NAME = 'int';
 
 	/**
 	 * @see StringValueParser::stringParse

--- a/src/ValueParsers/Normalizers/NullStringNormalizer.php
+++ b/src/ValueParsers/Normalizers/NullStringNormalizer.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
  *
  * @since 0.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class NullStringNormalizer implements StringNormalizer {

--- a/src/ValueParsers/Normalizers/StringNormalizer.php
+++ b/src/ValueParsers/Normalizers/StringNormalizer.php
@@ -9,7 +9,7 @@ use InvalidArgumentException;
  *
  * @since 0.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 interface StringNormalizer {

--- a/src/ValueParsers/NullParser.php
+++ b/src/ValueParsers/NullParser.php
@@ -9,7 +9,7 @@ use DataValues\UnknownValue;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class NullParser implements ValueParser {

--- a/src/ValueParsers/StringParser.php
+++ b/src/ValueParsers/StringParser.php
@@ -11,7 +11,7 @@ use ValueParsers\Normalizers\StringNormalizer;
  *
  * @since 0.3
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class StringParser implements ValueParser {

--- a/src/ValueParsers/StringValueParser.php
+++ b/src/ValueParsers/StringValueParser.php
@@ -13,7 +13,7 @@ use RuntimeException;
  *
  * @since 0.1
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 abstract class StringValueParser implements ValueParser {

--- a/tests/DataValues/MonolingualTextValueTest.php
+++ b/tests/DataValues/MonolingualTextValueTest.php
@@ -15,7 +15,7 @@ use PHPUnit\Framework\TestCase;
  * @group DataValue
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class MonolingualTextValueTest extends TestCase {

--- a/tests/DataValues/MultilingualTextValueTest.php
+++ b/tests/DataValues/MultilingualTextValueTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  * @group DataValue
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class MultilingualTextValueTest extends TestCase {

--- a/tests/ValueFormatters/Exceptions/MismatchingDataValueTypeExceptionTest.php
+++ b/tests/ValueFormatters/Exceptions/MismatchingDataValueTypeExceptionTest.php
@@ -12,7 +12,7 @@ use ValueFormatters\Exceptions\MismatchingDataValueTypeException;
  * @group ValueFormatters
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  * @author Thiemo Kreuz
  */

--- a/tests/ValueFormatters/StringFormatterTest.php
+++ b/tests/ValueFormatters/StringFormatterTest.php
@@ -13,7 +13,7 @@ use ValueFormatters\StringFormatter;
  * @group ValueFormatters
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Katie Filbert < aude.wiki@gmail.com >
  */
 class StringFormatterTest extends TestCase {

--- a/tests/ValueParsers/BoolParserTest.php
+++ b/tests/ValueParsers/BoolParserTest.php
@@ -12,7 +12,7 @@ use ValueParsers\BoolParser;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class BoolParserTest extends StringValueParserTest {

--- a/tests/ValueParsers/DispatchingValueParserTest.php
+++ b/tests/ValueParsers/DispatchingValueParserTest.php
@@ -15,7 +15,7 @@ use ValueParsers\ValueParser;
  * @group DataValueExtensions
  * @group ValueParsers
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class DispatchingValueParserTest extends TestCase {

--- a/tests/ValueParsers/FloatParserTest.php
+++ b/tests/ValueParsers/FloatParserTest.php
@@ -12,7 +12,7 @@ use ValueParsers\FloatParser;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class FloatParserTest extends StringValueParserTest {

--- a/tests/ValueParsers/IntParserTest.php
+++ b/tests/ValueParsers/IntParserTest.php
@@ -12,7 +12,7 @@ use ValueParsers\IntParser;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class IntParserTest extends StringValueParserTest {

--- a/tests/ValueParsers/Normalizers/NullStringNormalizerTest.php
+++ b/tests/ValueParsers/Normalizers/NullStringNormalizerTest.php
@@ -13,7 +13,7 @@ use ValueParsers\Normalizers\NullStringNormalizer;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Thiemo Kreuz
  */
 class NullStringNormalizerTest extends TestCase {

--- a/tests/ValueParsers/NullParserTest.php
+++ b/tests/ValueParsers/NullParserTest.php
@@ -12,7 +12,7 @@ use ValueParsers\ValueParser;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 class NullParserTest extends ValueParserTestBase {

--- a/tests/ValueParsers/StringParserTest.php
+++ b/tests/ValueParsers/StringParserTest.php
@@ -15,7 +15,7 @@ use ValueParsers\StringParser;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Daniel Kinzler
  */
 class StringParserTest extends TestCase {

--- a/tests/ValueParsers/StringParserTest.php
+++ b/tests/ValueParsers/StringParserTest.php
@@ -37,7 +37,7 @@ class StringParserTest extends TestCase {
 	/**
 	 * @dataProvider provideParse
 	 */
-	public function testParse( $input, StringNormalizer $normalizer = null, DataValue $expected ) {
+	public function testParse( $input, ?StringNormalizer $normalizer, DataValue $expected ) {
 		$parser = new StringParser( $normalizer );
 		$value = $parser->parse( $input );
 

--- a/tests/ValueParsers/StringParserTest.php
+++ b/tests/ValueParsers/StringParserTest.php
@@ -4,7 +4,6 @@ namespace ValueParsers\Test;
 
 use DataValues\DataValue;
 use DataValues\StringValue;
-use InvalidArgumentException;
 use PHPUnit\Framework\TestCase;
 use ValueParsers\Normalizers\StringNormalizer;
 use ValueParsers\ParseException;

--- a/tests/ValueParsers/StringValueParserTest.php
+++ b/tests/ValueParsers/StringValueParserTest.php
@@ -11,7 +11,7 @@ use ValueParsers\StringValueParser;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 abstract class StringValueParserTest extends ValueParserTestBase {

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -16,7 +16,7 @@ use ValueParsers\ValueParser;
  * @group ValueParsers
  * @group DataValueExtensions
  *
- * @license GPL-2.0+
+ * @license GPL-2.0-or-later
  * @author Jeroen De Dauw < jeroendedauw@gmail.com >
  */
 abstract class ValueParserTestBase extends TestCase {


### PR DESCRIPTION
This PR updates the `wikibase-codesniffer` to the latest version and fixes the CS violations that arose due to the update.

Issue: [T264867](https://phabricator.wikimedia.org/T264867)