### PR TITLE
Upgrade mediawiki-codesniffer to latest version (45.0.0)

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -13,8 +13,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.2'
-          - '7.3'
           - '7.4'
 
     steps:

--- a/composer.json
+++ b/composer.json
@@ -23,14 +23,14 @@
 		"irc": "irc://irc.freenode.net/wikidata"
 	},
 	"require": {
-		"php": ">=7.2.0",
+		"php": ">=7.4",
 		"data-values/data-values": "~3.0|~2.0|~1.0|~0.1",
 		"data-values/interfaces": "~1.0|~0.2.0"
 	},
 	"require-dev": {
 		"phpunit/phpunit": "~8.0",
 		"ockcyp/covers-validator": "^1.3.3",
-		"mediawiki/mediawiki-codesniffer": "^34"
+		"mediawiki/mediawiki-codesniffer": "^45"
 	},
 	"extra": {
 		"branch-alias": {
@@ -67,5 +67,10 @@
 			"@cs",
 			"@test"
 		]
+	},
+	"config": {
+		"allow-plugins": {
+			"dealerdirect/phpcodesniffer-composer-installer": true
+		}
 	}
 }

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -7,4 +7,5 @@
 		<exclude name="Generic.Files.LineLength.TooLong" />
 		<exclude name="Generic.Files.LineLength.MaxExceeded" />
 	</rule>
+	<rule ref="./vendor/mediawiki/mediawiki-codesniffer/MediaWiki"/>
 </ruleset>

--- a/src/DataValues/MonolingualTextValue.php
+++ b/src/DataValues/MonolingualTextValue.php
@@ -65,7 +65,7 @@ class MonolingualTextValue extends DataValueObject {
 	}
 
 	public function __unserialize( array $data ): void {
-		list( $languageCode, $text ) = $data;
+		[ $languageCode, $text ] = $data;
 		$this->__construct( $languageCode, $text );
 	}
 

--- a/src/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
+++ b/src/ValueFormatters/Exceptions/MismatchingDataValueTypeException.php
@@ -36,7 +36,7 @@ class MismatchingDataValueTypeException extends FormattingException {
 		$expectedValueType,
 		$dataValueType,
 		$message = '',
-		Exception $previous = null
+		?Exception $previous = null
 	) {
 		$this->expectedValueType = $expectedValueType;
 		$this->dataValueType = $dataValueType;

--- a/src/ValueParsers/BoolParser.php
+++ b/src/ValueParsers/BoolParser.php
@@ -18,6 +18,10 @@ class BoolParser extends StringValueParser {
 
 	private const FORMAT_NAME = 'bool';
 
+	/**
+	 * @var Mapping from possible string values to their
+	 *      boolean equivalents
+	 */
 	private static $values = [
 		'yes' => true,
 		'on' => true,

--- a/src/ValueParsers/StringParser.php
+++ b/src/ValueParsers/StringParser.php
@@ -26,7 +26,7 @@ class StringParser implements ValueParser {
 	/**
 	 * @param StringNormalizer|null $normalizer
 	 */
-	public function __construct( StringNormalizer $normalizer = null ) {
+	public function __construct( ?StringNormalizer $normalizer = null ) {
 		$this->normalizer = $normalizer ?: new NullStringNormalizer();
 	}
 

--- a/src/ValueParsers/StringValueParser.php
+++ b/src/ValueParsers/StringValueParser.php
@@ -28,7 +28,7 @@ abstract class StringValueParser implements ValueParser {
 	/**
 	 * @param ParserOptions|null $options
 	 */
-	public function __construct( ParserOptions $options = null ) {
+	public function __construct( ?ParserOptions $options = null ) {
 		$this->options = $options ?: new ParserOptions();
 
 		$this->defaultOption( ValueParser::OPT_LANG, 'en' );

--- a/tests/ValueParsers/DispatchingValueParserTest.php
+++ b/tests/ValueParsers/DispatchingValueParserTest.php
@@ -22,17 +22,17 @@ use ValueParsers\ValueParser;
  */
 class DispatchingValueParserTest extends TestCase {
 
-	private function getParser( $invocation ) : ValueParser {
+	private function getParser( $invocation ): ValueParser {
 		$mock = $this->createMock( ValueParser::class );
 
 		$mock->expects( $invocation )
 			->method( 'parse' )
-			->will( $this->returnCallback( function( $value ) {
+			->willReturnCallback( static function ( $value ) {
 				if ( $value === 'invalid' ) {
 					throw new ParseException( 'failed' );
 				}
 				return $value;
-			} ) );
+			} );
 
 		return $mock;
 	}

--- a/tests/ValueParsers/NullParserTest.php
+++ b/tests/ValueParsers/NullParserTest.php
@@ -55,7 +55,7 @@ class NullParserTest extends ValueParserTestBase {
 	 *
 	 * @dataProvider invalidInputProvider
 	 */
-	public function testParseWithInvalidInputs( $value, ValueParser $parser = null ) {
+	public function testParseWithInvalidInputs( $value, ?ValueParser $parser = null ) {
 		$this->markTestSkipped( 'NullParser has no invalid inputs' );
 	}
 

--- a/tests/ValueParsers/StringParserTest.php
+++ b/tests/ValueParsers/StringParserTest.php
@@ -26,9 +26,9 @@ class StringParserTest extends TestCase {
 		$normalizer = $this->createMock( StringNormalizer::class );
 		$normalizer->expects( $this->once() )
 			->method( 'normalize' )
-			->will( $this->returnCallback( function( $value ) {
+			->willReturnCallback( static function ( $value ) {
 				return strtolower( trim( $value ) );
-			} ) );
+			} );
 
 		return [
 			'simple' => [ 'hello world', null, new StringValue( 'hello world' ) ],

--- a/tests/ValueParsers/ValueParserTestBase.php
+++ b/tests/ValueParsers/ValueParserTestBase.php
@@ -44,7 +44,7 @@ abstract class ValueParserTestBase extends TestCase {
 	 * @param mixed $expected
 	 * @param ValueParser|null $parser
 	 */
-	public function testParseWithValidInputs( $value, $expected, ValueParser $parser = null ) {
+	public function testParseWithValidInputs( $value, $expected, ?ValueParser $parser = null ) {
 		if ( $parser === null ) {
 			$parser = $this->getInstance();
 		}
@@ -77,7 +77,7 @@ abstract class ValueParserTestBase extends TestCase {
 	 * @param mixed $value
 	 * @param ValueParser|null $parser
 	 */
-	public function testParseWithInvalidInputs( $value, ValueParser $parser = null ) {
+	public function testParseWithInvalidInputs( $value, ?ValueParser $parser = null ) {
 		if ( $parser === null ) {
 			$parser = $this->getInstance();
 		}


### PR DESCRIPTION
This repository is currently using version 34 of the Mediawiki coding style phpcs rules. If the code aims to comply with Mediawiki style guidelines, it makes sense that it continues to comply at current versions of the rules.

Besides being simply different, the newer versions of the rules introduce, for example,
MediaWiki.Usage.NullableType.ExplicitNullableTypes, which enforces compliance with coming deprecation rules in PHP 8.4 concerning nullable types. If the code does not remove the soon-to-be-deprecated form of nullable type declarations, the library will no longer be usable in Mediawiki for PHP 8.4 deployments.

Resolves #100

Bug: T379481